### PR TITLE
Load transactions from node

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "typescript": "^3.9.3"
   },
   "dependencies": {
+    "nano-rpc-fetch": "^0.0.9",
+    "nanocurrency-web": "^1.2.2",
     "redux": "^4.0.5",
     "sirv-cli": "^1.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "typescript": "^3.9.3"
   },
   "dependencies": {
-    "nano-rpc-fetch": "^0.0.9",
+    "nano-rpc-fetch": "^1.0.0",
     "nanocurrency-web": "^1.2.2",
     "redux": "^4.0.5",
     "sirv-cli": "^1.0.0"

--- a/public/locales/en-US.properties
+++ b/public/locales/en-US.properties
@@ -22,3 +22,6 @@ wallets = Wallets
 
 #QRCode Send
 sendQRCodeHeadline = Send via QR Code
+
+#Transactions
+transactions = Transactions

--- a/public/locales/en-US.properties
+++ b/public/locales/en-US.properties
@@ -25,3 +25,6 @@ sendQRCodeHeadline = Send via QR Code
 
 #Transactions
 transactions = Transactions
+transaction-received = Got
+transaction-sent = Sent
+transaction-from = from

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -59,7 +59,7 @@
 	</div>
 	<div class="kui-content-area" id="content-area">
 		{#if view === RECEIVE_VIEW.viewKey}
-			<Transactions />
+			<Receive />
 		{:else if view === SEND_VIEW.viewKey}
 			<Send />
 		{:else if view === BALANCE_VIEW.viewKey}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -9,11 +9,11 @@
 	import Setup from "./view/Setup.svelte";
 	import Send from "./view/Send.svelte";
 	import About from "./view/About.svelte";
-	import {resolveHistory} from "./machinery/nano-rpc";
 	import Transactions from "./view/Transactions.svelte";
 
-	let header = "Receive"
-	let view = RECEIVE_VIEW.viewKey
+	let header: string | undefined = undefined
+	let view: string | undefined = undefined
+
 	let views = []
 
 	const unsubscribe = viewStore.subscribe(value => {
@@ -59,6 +59,8 @@
 	</div>
 	<div class="kui-content-area" id="content-area">
 		{#if view === RECEIVE_VIEW.viewKey}
+			<Receive />
+		{:else if view === RECEIVE_VIEW.viewKey}
 			<Receive />
 		{:else if view === SEND_VIEW.viewKey}
 			<Send />

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import Receive from "./view/Receive.svelte";
 	import {loadedComponentStore, viewStore} from "./stores/stores";
-	import {RECEIVE_VIEW, MENU_VIEW, BALANCE_VIEW, SETUP_VIEW, SEND_VIEW, ABOUT_VIEW, BACK} from "./constants/views";
+	import {RECEIVE_VIEW, MENU_VIEW, BALANCE_VIEW, SETUP_VIEW, SEND_VIEW, ABOUT_VIEW, BACK, TRANSACTIONS_VIEW} from "./constants/views";
 	import Menu from "./view/Menu.svelte";
 	import {onMount} from "svelte";
 	import {handleKeydown} from "./machinery/eventListener";
@@ -9,6 +9,8 @@
 	import Setup from "./view/Setup.svelte";
 	import Send from "./view/Send.svelte";
 	import About from "./view/About.svelte";
+	import {resolveHistory} from "./machinery/nano-rpc";
+	import Transactions from "./view/Transactions.svelte";
 
 	let header = "Receive"
 	let view = RECEIVE_VIEW.viewKey
@@ -20,7 +22,7 @@
 			let current = views.pop()
 			let next = views.pop()
 			viewStore.set(next)
-		} else if(viewKey) {
+		} else if (viewKey) {
 			header = title;
 			view = viewKey;
 			views.push(value)
@@ -62,6 +64,8 @@
 			<Send />
 		{:else if view === BALANCE_VIEW.viewKey}
 			<Balance />
+		{:else if view === TRANSACTIONS_VIEW.viewKey}
+			<Transactions />
 		{:else if view === SETUP_VIEW.viewKey}
 			<Setup />
 		{:else if view === MENU_VIEW.viewKey}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -59,7 +59,7 @@
 	</div>
 	<div class="kui-content-area" id="content-area">
 		{#if view === RECEIVE_VIEW.viewKey}
-			<Receive />
+			<Transactions />
 		{:else if view === SEND_VIEW.viewKey}
 			<Send />
 		{:else if view === BALANCE_VIEW.viewKey}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,7 +1,17 @@
 <script lang="ts">
 	import Receive from "./view/Receive.svelte";
 	import {loadedComponentStore, viewStore} from "./stores/stores";
-	import {RECEIVE_VIEW, MENU_VIEW, BALANCE_VIEW, SETUP_VIEW, SEND_VIEW, ABOUT_VIEW, BACK, TRANSACTIONS_VIEW} from "./constants/views";
+	import {
+		RECEIVE_VIEW,
+		MENU_VIEW,
+		BALANCE_VIEW,
+		SETUP_VIEW,
+		SEND_VIEW,
+		ABOUT_VIEW,
+		BACK,
+		TRANSACTIONS_VIEW,
+	} from "./constants/views";
+	import type { View } from "./constants/views";
 	import Menu from "./view/Menu.svelte";
 	import {onMount} from "svelte";
 	import {handleKeydown} from "./machinery/eventListener";
@@ -16,7 +26,7 @@
 
 	let views = []
 
-	const unsubscribe = viewStore.subscribe(value => {
+	const unsubscribe = viewStore.subscribe<View>(value => {
 		const {viewKey, title} = value;
 		if (viewKey && viewKey === BACK.viewKey) {
 			let current = views.pop()

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -70,8 +70,6 @@
 	<div class="kui-content-area" id="content-area">
 		{#if view === RECEIVE_VIEW.viewKey}
 			<Receive />
-		{:else if view === RECEIVE_VIEW.viewKey}
-			<Receive />
 		{:else if view === SEND_VIEW.viewKey}
 			<Send />
 		{:else if view === BALANCE_VIEW.viewKey}

--- a/src/components/list/ListItem.svelte
+++ b/src/components/list/ListItem.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+    export let primaryLanguageId: string;
+</script>
+<li tabindex="1" class="navigation" on:click>
+    <div class="kui-list-cont">
+        <p class="kui-pri" data-l10n-id="{primaryLanguageId}">
+            <slot />
+        </p>
+    </div>
+</li>

--- a/src/components/list/ListItem.svelte
+++ b/src/components/list/ListItem.svelte
@@ -1,10 +1,5 @@
-<script lang="ts">
-    export let primaryLanguageId: string;
-</script>
 <li tabindex="1" class="navigation" on:click>
     <div class="kui-list-cont">
-        <p class="kui-pri" data-l10n-id="{primaryLanguageId}">
-            <slot />
-        </p>
+        <slot />
     </div>
 </li>

--- a/src/components/list/Primary.svelte
+++ b/src/components/list/Primary.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
+    import ListItem from "./ListItem.svelte";
     export let primaryLanguageId: string;
     export let primaryText: string;
 </script>
-<li tabindex="1" class="navigation" on:click>
-    <div class="kui-list-cont">
-        <p class="kui-pri" data-l10n-id="{primaryLanguageId}">{primaryText}</p>
-    </div>
-</li>
+<ListItem primaryLanguageId={primaryLanguageId} on:click>
+    {primaryText}
+</ListItem>

--- a/src/components/list/Primary.svelte
+++ b/src/components/list/Primary.svelte
@@ -3,6 +3,8 @@
     export let primaryLanguageId: string;
     export let primaryText: string;
 </script>
-<ListItem primaryLanguageId={primaryLanguageId} on:click>
-    {primaryText}
+<ListItem on:click>
+    <p class="kui-pri" data-l10n-id="{primaryLanguageId}">
+        {primaryText}
+    </p>
 </ListItem>

--- a/src/constants/views.ts
+++ b/src/constants/views.ts
@@ -8,11 +8,6 @@ export const SETUP_VIEW: View = {
     title: "Setup",
 }
 
-export const WALLET_VIEW = {
-    viewKey: "WALLET_VIEW",
-    title: "Wallet"
-}
-
 export const RECEIVE_VIEW = {
     viewKey: "RECEIVE_VIEW",
     title: "Receive"

--- a/src/constants/views.ts
+++ b/src/constants/views.ts
@@ -1,4 +1,4 @@
-interface View {
+export interface View {
     viewKey: string
     title: string
 }

--- a/src/constants/views.ts
+++ b/src/constants/views.ts
@@ -8,6 +8,11 @@ export const SETUP_VIEW: View = {
     title: "Setup",
 }
 
+export const WALLET_VIEW = {
+    viewKey: "WALLET_VIEW",
+    title: "Wallet"
+}
+
 export const RECEIVE_VIEW = {
     viewKey: "RECEIVE_VIEW",
     title: "Receive"

--- a/src/constants/views.ts
+++ b/src/constants/views.ts
@@ -21,6 +21,10 @@ export const BALANCE_VIEW = {
     viewKey: "BALANCE_VIEW",
     title: "Balance",
 };
+export const TRANSACTIONS_VIEW = {
+    viewKey: "TRANSACTIONS_VIEW",
+    title: "Transactions",
+};
 export const SEND_VIEW = {
     viewKey: "SEND_VIEW",
     title: "Send"

--- a/src/machinery/models.ts
+++ b/src/machinery/models.ts
@@ -1,0 +1,19 @@
+export type NanoAddress = string
+export type Seed = string
+
+export interface Account {
+    alias: string
+    address: NanoAddress
+}
+
+export interface Wallet {
+    accounts: Account[]
+    seed: Seed
+}
+
+export interface NanoTransaction {
+    account: NanoAddress
+    amount: string
+    type: string
+    localTimestamp: string
+}

--- a/src/machinery/nano-rpc.ts
+++ b/src/machinery/nano-rpc.ts
@@ -1,0 +1,17 @@
+import {AccountHistoryRequestActionEnum, Configuration, NodeRPCsApi} from "nano-rpc-fetch";
+import type {AccountHistoryRequest, AccountHistoryResponse} from "nano-rpc-fetch";
+
+const nanoApi = new NodeRPCsApi(new Configuration({
+    basePath: "https://nano.mehl.no/node"
+}));
+
+export function resolveHistory(address: string): Promise<AccountHistoryResponse> {
+    return nanoApi.accountHistory({
+        // @ts-ignore
+        accountHistoryRequest: {
+            action: AccountHistoryRequestActionEnum.AccountHistory,
+            account: address,
+            count: "10"
+        }
+    })
+}

--- a/src/machinery/nano-rpc.ts
+++ b/src/machinery/nano-rpc.ts
@@ -1,17 +1,32 @@
 import {AccountHistoryRequestActionEnum, Configuration, NodeRPCsApi} from "nano-rpc-fetch";
 import type {AccountHistoryRequest, AccountHistoryResponse} from "nano-rpc-fetch";
 
+type NanoAccount = string
+
+export interface NanoTransaction {
+    account: NanoAccount
+    amount: number
+    type: string
+}
+
 const nanoApi = new NodeRPCsApi(new Configuration({
     basePath: "https://nano.mehl.no/node"
 }));
 
-export function resolveHistory(address: string): Promise<AccountHistoryResponse> {
-    return nanoApi.accountHistory({
-        // @ts-ignore
+export async function resolveHistory(address: string): Promise<NanoTransaction[]> {
+    let history: AccountHistoryResponse = await nanoApi.accountHistory({
+        // @ts-ignore TODO: Fix the library exporting these wrong
         accountHistoryRequest: {
             action: AccountHistoryRequestActionEnum.AccountHistory,
             account: address,
             count: "10"
+        }
+    })
+    return history.history.map(block => {
+        return {
+            account: block.account,
+            amount: block.amount,
+            type: block.type
         }
     })
 }

--- a/src/machinery/nano-rpc.ts
+++ b/src/machinery/nano-rpc.ts
@@ -1,15 +1,7 @@
 import {AccountHistoryRequestActionEnum, Configuration, NodeRPCsApi} from "nano-rpc-fetch";
 import type {AccountHistoryRequest, AccountHistoryResponse} from "nano-rpc-fetch";
 import { tools } from 'nanocurrency-web'
-
-type NanoAccount = string
-
-export interface NanoTransaction {
-    account: NanoAccount
-    amount: string
-    type: string
-    localTimestamp: string
-}
+import type {NanoTransaction} from "./models";
 
 const nanoApi = new NodeRPCsApi(new Configuration({
     basePath: "https://nano.mehl.no/node"

--- a/src/machinery/nano-rpc.ts
+++ b/src/machinery/nano-rpc.ts
@@ -8,6 +8,7 @@ export interface NanoTransaction {
     account: NanoAccount
     amount: string
     type: string
+    localTimestamp: string
 }
 
 const nanoApi = new NodeRPCsApi(new Configuration({
@@ -27,7 +28,8 @@ export async function resolveHistory(address: string): Promise<NanoTransaction[]
         return {
             account: block.account,
             amount: rawToNano(block.amount, 5),
-            type: block.type
+            type: block.type,
+            localTimestamp: block.localTimestamp
         }
     })
 }

--- a/src/machinery/nano-rpc.ts
+++ b/src/machinery/nano-rpc.ts
@@ -1,11 +1,12 @@
 import {AccountHistoryRequestActionEnum, Configuration, NodeRPCsApi} from "nano-rpc-fetch";
 import type {AccountHistoryRequest, AccountHistoryResponse} from "nano-rpc-fetch";
+import { tools } from 'nanocurrency-web'
 
 type NanoAccount = string
 
 export interface NanoTransaction {
     account: NanoAccount
-    amount: number
+    amount: string
     type: string
 }
 
@@ -25,8 +26,12 @@ export async function resolveHistory(address: string): Promise<NanoTransaction[]
     return history.history.map(block => {
         return {
             account: block.account,
-            amount: block.amount,
+            amount: rawToNano(block.amount, 5),
             type: block.type
         }
     })
+}
+
+function rawToNano(raw: number, fractions?: number): string {
+    return Number.parseFloat(tools.convert(raw.toString(), 'RAW', 'NANO')).toFixed(fractions)
 }

--- a/src/machinery/nano-rpc.ts
+++ b/src/machinery/nano-rpc.ts
@@ -9,7 +9,6 @@ const nanoApi = new NodeRPCsApi(new Configuration({
 
 export async function resolveHistory(address: string): Promise<NanoTransaction[]> {
     let history: AccountHistoryResponse = await nanoApi.accountHistory({
-        // @ts-ignore TODO: Fix the library exporting these wrong
         accountHistoryRequest: {
             action: AccountHistoryRequestActionEnum.AccountHistory,
             account: address,

--- a/src/stores/stores.js
+++ b/src/stores/stores.js
@@ -1,6 +1,0 @@
-import { writable } from 'svelte/store';
-import {RECEIVE_VIEW} from "../constants/views";
-
-export const viewStore = writable(RECEIVE_VIEW);
-export const loadedComponentStore = writable({})
-

--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -1,0 +1,7 @@
+import {Writable, writable} from 'svelte/store';
+import {RECEIVE_VIEW} from "../constants/views";
+import type {View} from "../constants/views";
+
+export const viewStore: Writable<View> = writable<View>(RECEIVE_VIEW);
+export const loadedComponentStore = writable({})
+

--- a/src/view/Menu.svelte
+++ b/src/view/Menu.svelte
@@ -1,6 +1,6 @@
 <script>
     import {viewStore} from "../stores/stores";
-    import {ABOUT_VIEW, BALANCE_VIEW, RECEIVE_VIEW, SEND_VIEW, SETUP_VIEW} from "../constants/views";
+    import {ABOUT_VIEW, BALANCE_VIEW, RECEIVE_VIEW, SEND_VIEW, SETUP_VIEW, TRANSACTIONS_VIEW} from "../constants/views";
     import List from "../components/List.svelte";
     import Primary from "../components/list/Primary.svelte";
 </script>
@@ -10,6 +10,7 @@
         <Primary primaryLanguageId="receive" primaryText="receive" on:click={() => viewStore.set(RECEIVE_VIEW)}/>
         <Primary primaryLanguageId="send" primaryText="send" on:click={() => viewStore.set(SEND_VIEW)}/>
         <Primary primaryLanguageId="balance" primaryText="balance" on:click={() => viewStore.set(BALANCE_VIEW)}/>
+        <Primary primaryLanguageId="transactions" primaryText="transactions" on:click={() => viewStore.set(TRANSACTIONS_VIEW)}/>
         <Primary primaryLanguageId="about" primaryText="about" on:click={() => viewStore.set(ABOUT_VIEW)}/>
         <Primary primaryLanguageId="setup" primaryText="setup" on:click={() => viewStore.set(SETUP_VIEW)}/>
     </List>

--- a/src/view/Transactions.svelte
+++ b/src/view/Transactions.svelte
@@ -19,18 +19,27 @@
             errorLoading = true
         }
     })
+
+    let selected: NanoTransaction | undefined = undefined
+
+    const setSelected = (time) => {
+        selected = history.filter(h => h.localTimestamp === time)[0]
+    }
 </script>
 
 <div>
-    {#if history.length > 0}
+    {#if selected}
+        <div>{selected.localTimestamp}</div>
+    {:else if history.length > 0}
         <List>
-        {#each history as transaction}
-            <ListItem><Transaction transaction={transaction} /></ListItem>
-        {/each}
+            {#each history as transaction}
+                <ListItem on:click={() => setSelected(transaction.localTimestamp)}><Transaction transaction={transaction}/></ListItem>
+            {/each}
         </List>
     {:else if errorLoading}
         unable to load transactions
     {:else}
         loading history
     {/if}
+
 </div>

--- a/src/view/Transactions.svelte
+++ b/src/view/Transactions.svelte
@@ -4,6 +4,9 @@
     import type {NanoTransaction} from "../machinery/nano-rpc";
     import type {AccountHistoryResponse} from "nano-rpc-fetch";
     import Transaction from "./transactions/Transaction.svelte";
+    import List from "../components/List.svelte";
+    import Primary from "../components/list/Primary.svelte";
+    import ListItem from "../components/list/ListItem.svelte";
 
     const arbitraryAccount = "nano_1ninja7rh37ehfp9utkor5ixmxyg8kme8fnzc4zty145ibch8kf5jwpnzr3r"
     let history: NanoTransaction[] = []
@@ -12,7 +15,6 @@
     onMount(async () => {
         try {
             history = await resolveHistory(arbitraryAccount)
-            console.log(history)
         } catch (error) {
             errorLoading = true
         }
@@ -21,9 +23,11 @@
 
 <div>
     {#if history.length > 0}
+        <List>
         {#each history as transaction}
-            <Transaction transaction={transaction} />
+            <ListItem><Transaction transaction={transaction} /></ListItem>
         {/each}
+        </List>
     {:else if errorLoading}
         unable to load transactions
     {:else}

--- a/src/view/Transactions.svelte
+++ b/src/view/Transactions.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+    import {onMount} from "svelte";
+    import {resolveHistory} from "../machinery/nano-rpc";
+    import type {AccountHistoryResponse} from "nano-rpc-fetch";
+
+    const arbitraryAccount = "nano_1ninja7rh37ehfp9utkor5ixmxyg8kme8fnzc4zty145ibch8kf5jwpnzr3r"
+    let history: AccountHistoryResponse | undefined = undefined
+    let errorLoading: boolean = false
+
+    onMount(async () => {
+        try {
+            history = await resolveHistory(arbitraryAccount)
+        } catch (error) {
+            errorLoading = true
+        }
+    })
+</script>
+
+<div>
+    {#if history}
+    {:else if errorLoading}
+        unable to load transactions
+    {:else}
+        loading history
+    {/if}
+</div>

--- a/src/view/Transactions.svelte
+++ b/src/view/Transactions.svelte
@@ -1,15 +1,18 @@
 <script lang="ts">
     import {onMount} from "svelte";
     import {resolveHistory} from "../machinery/nano-rpc";
+    import type {NanoTransaction} from "../machinery/nano-rpc";
     import type {AccountHistoryResponse} from "nano-rpc-fetch";
+    import Transaction from "./transactions/Transaction.svelte";
 
     const arbitraryAccount = "nano_1ninja7rh37ehfp9utkor5ixmxyg8kme8fnzc4zty145ibch8kf5jwpnzr3r"
-    let history: AccountHistoryResponse | undefined = undefined
+    let history: NanoTransaction[] = []
     let errorLoading: boolean = false
 
     onMount(async () => {
         try {
             history = await resolveHistory(arbitraryAccount)
+            console.log(history)
         } catch (error) {
             errorLoading = true
         }
@@ -17,7 +20,10 @@
 </script>
 
 <div>
-    {#if history}
+    {#if history.length > 0}
+        {#each history as transaction}
+            <Transaction transaction={transaction} />
+        {/each}
     {:else if errorLoading}
         unable to load transactions
     {:else}

--- a/src/view/Transactions.svelte
+++ b/src/view/Transactions.svelte
@@ -1,20 +1,19 @@
 <script lang="ts">
     import {onMount} from "svelte";
     import {resolveHistory} from "../machinery/nano-rpc";
-    import type {NanoTransaction} from "../machinery/nano-rpc";
-    import type {AccountHistoryResponse} from "nano-rpc-fetch";
     import Transaction from "./transactions/Transaction.svelte";
     import List from "../components/List.svelte";
-    import Primary from "../components/list/Primary.svelte";
     import ListItem from "../components/list/ListItem.svelte";
+    import type {NanoAddress, NanoTransaction} from "../machinery/models";
 
-    const arbitraryAccount = "nano_1ninja7rh37ehfp9utkor5ixmxyg8kme8fnzc4zty145ibch8kf5jwpnzr3r"
+    export let address: NanoAddress = "nano_3rw4un6ys57hrb39sy1qx8qy5wukst1iiponztrz9qiz6qqa55kxzx4491or"
+
     let history: NanoTransaction[] = []
     let errorLoading: boolean = false
 
     onMount(async () => {
         try {
-            history = await resolveHistory(arbitraryAccount)
+            history = await resolveHistory(address)
         } catch (error) {
             errorLoading = true
         }

--- a/src/view/transactions/Transaction.svelte
+++ b/src/view/transactions/Transaction.svelte
@@ -2,13 +2,19 @@
     import type { NanoTransaction } from "../../machinery/nano-rpc";
 
     export let transaction: NanoTransaction
-</script>
 
-{#if transaction.type === 'receive'}
-    <span data-l10n-id="transaction-received"></span>
-{:else}
-    <span data-l10n-id="transaction-sent"></span>
-{/if}
+    const transactionType = () => {
+        switch (transaction.type) {
+            case 'receive':
+                return "transaction-received"
+            case 'send':
+                return "transaction-sent"
+            default:
+                return "unknown"
+        }
+    }
+</script>
+<span data-l10n-id={transactionType()}></span>
 {transaction.amount}
 <span data-l10n-id="transaction-from"></span>
 {transaction.account}

--- a/src/view/transactions/Transaction.svelte
+++ b/src/view/transactions/Transaction.svelte
@@ -2,6 +2,7 @@
     import type { NanoTransaction } from "../../machinery/nano-rpc";
 
     export let transaction: NanoTransaction
+    let expand: boolean = false
 
     const transactionType = () => {
         switch (transaction.type) {
@@ -13,8 +14,19 @@
                 return "unknown"
         }
     }
+
+    const onClick = () => {
+        expand = !expand
+    }
 </script>
-<span data-l10n-id={transactionType()}></span>
-{transaction.amount}
-<span data-l10n-id="transaction-from"></span>
-{transaction.account}
+<div on:click={onClick}>
+    <span data-l10n-id={transactionType()}></span>
+    {transaction.amount}
+    <span data-l10n-id="transaction-from"></span>
+    {transaction.account}
+    {#if expand}
+        <div>
+            {transaction.localTimestamp}
+        </div>
+    {/if}
+</div>

--- a/src/view/transactions/Transaction.svelte
+++ b/src/view/transactions/Transaction.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+    import type { NanoTransaction } from "../../machinery/nano-rpc";
+
+    export let transaction: NanoTransaction
+</script>
+
+<div>
+    {transaction.account}
+</div>

--- a/src/view/transactions/Transaction.svelte
+++ b/src/view/transactions/Transaction.svelte
@@ -4,6 +4,11 @@
     export let transaction: NanoTransaction
 </script>
 
-<div>
-    {transaction.account}
-</div>
+{#if transaction.type === 'receive'}
+    <span data-l10n-id="transaction-received"></span>
+{:else}
+    <span data-l10n-id="transaction-sent"></span>
+{/if}
+{transaction.amount}
+<span data-l10n-id="transaction-from"></span>
+{transaction.account}

--- a/src/view/transactions/Transaction.svelte
+++ b/src/view/transactions/Transaction.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import type { NanoTransaction } from "../../machinery/nano-rpc";
+    import type { NanoTransaction } from "../../machinery/models";
 
     export let transaction: NanoTransaction
 

--- a/src/view/transactions/Transaction.svelte
+++ b/src/view/transactions/Transaction.svelte
@@ -2,7 +2,6 @@
     import type { NanoTransaction } from "../../machinery/nano-rpc";
 
     export let transaction: NanoTransaction
-    let expand: boolean = false
 
     const transactionType = () => {
         switch (transaction.type) {
@@ -14,19 +13,10 @@
                 return "unknown"
         }
     }
-
-    const onClick = () => {
-        expand = !expand
-    }
 </script>
-<div on:click={onClick}>
+<div>
     <span data-l10n-id={transactionType()}></span>
     {transaction.amount}
     <span data-l10n-id="transaction-from"></span>
     {transaction.account}
-    {#if expand}
-        <div>
-            {transaction.localTimestamp}
-        </div>
-    {/if}
 </div>


### PR DESCRIPTION
Adds preliminary support for loading transactions from a node. Hard-coded account and a node instance we can use while developing/testing. Solves #8 