### PR TITLE
Menu suggestion

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,13 @@
     "@rollup/plugin-node-resolve": "^10.0.0",
     "@rollup/plugin-typescript": "^6.0.0",
     "@tsconfig/svelte": "^1.0.0",
+    "@types/qrcode": "^1.3.5",
     "kaios-gaia-l10n": "^0.0.1",
     "kaios-scripts": "^0.0.9",
     "rollup": "^2.3.4",
     "rollup-plugin-css-only": "^3.0.0",
     "rollup-plugin-livereload": "^2.0.0",
+    "rollup-plugin-node-polyfills": "^0.2.1",
     "rollup-plugin-svelte": "^7.0.0",
     "rollup-plugin-terser": "^7.0.0",
     "svelte": "^3.0.0",
@@ -34,6 +36,7 @@
   "dependencies": {
     "nano-rpc-fetch": "^1.0.0",
     "nanocurrency-web": "^1.2.2",
+    "qrcode": "^1.4.4",
     "redux": "^4.0.5",
     "sirv-cli": "^1.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "rollup -c",
     "dev": "rollup -c -w",
     "start": "sirv public",
-    "clean": "rm -r build/ public/build",
+    "clean": "rm -rf build/ public/build",
     "push": "yarn clean && yarn build && cp -r public/ build/ && kaios-scripts push",
     "validate": "svelte-check"
   },

--- a/public/locales/en-US.properties
+++ b/public/locales/en-US.properties
@@ -20,6 +20,9 @@ addWallet = Add wallet
 save = Save
 wallets = Wallets
 
+# send
+send-select = Select how to send
+
 #QRCode Send
 sendQRCodeHeadline = Send via QR Code
 

--- a/public/locales/en-US.properties
+++ b/public/locales/en-US.properties
@@ -21,7 +21,7 @@ addWallet = Add wallet
 save = Save
 wallets = Wallets
 
-# send
+#Send
 send-select = Select how to send
 
 #QRCode Send
@@ -32,3 +32,6 @@ transactions = Transactions
 transaction-received = Got
 transaction-sent = Sent
 transaction-from = from
+
+#Update
+update-button = Update

--- a/public/locales/en-US.properties
+++ b/public/locales/en-US.properties
@@ -12,6 +12,7 @@ setup = Setup
 #Receive
 generateAddress = Generate address
 selectYourWallet = Select your wallet
+receive-loading-qr = Loading QR code
 
 #Setup
 languages = Languages

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,6 +7,7 @@ import sveltePreprocess from 'svelte-preprocess';
 import typescript from '@rollup/plugin-typescript';
 import css from 'rollup-plugin-css-only';
 import multi from '@rollup/plugin-multi-entry';
+import nodePolyfills from 'rollup-plugin-node-polyfills';
 
 const production = !process.env.ROLLUP_WATCH;
 
@@ -66,6 +67,7 @@ export default {
 			sourceMap: !production,
 			inlineSources: !production
 		}),
+		nodePolyfills(),
 
 		// In dev mode, call `npm run start` once
 		// the bundle has been generated

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -11,7 +11,7 @@
 		BACK,
 		TRANSACTIONS_VIEW,
 	} from "./constants/views";
-	import type { View } from "./constants/views";
+	import type {View} from "./constants/views";
 	import Menu from "./view/Menu.svelte";
 	import {onMount} from "svelte";
 	import {handleKeydown} from "./machinery/eventListener";
@@ -20,6 +20,7 @@
 	import Send from "./view/Send.svelte";
 	import About from "./view/About.svelte";
 	import Transactions from "./view/Transactions.svelte";
+	import Wallet from "./view/Wallet.svelte";
 
 	let header: string | undefined = undefined
 	let view: string | undefined = undefined
@@ -69,7 +70,7 @@
 	</div>
 	<div class="kui-content-area" id="content-area">
 		{#if view === RECEIVE_VIEW.viewKey}
-			<Receive />
+			<Wallet />
 		{:else if view === SEND_VIEW.viewKey}
 			<Send />
 		{:else if view === BALANCE_VIEW.viewKey}

--- a/src/components/Button.svelte
+++ b/src/components/Button.svelte
@@ -1,11 +1,7 @@
 <script>
     export let text;
     export let languageId;
-
-    const onClick = () => {
-
-    }
 </script>
 
-<button class="navigation kui-btn" data-l10n-id="{languageId}" on:click={onClick}>{text}</button>
+<button class="navigation kui-btn" data-l10n-id="{languageId}" on:click>{text}</button>
 

--- a/src/machinery/eventListener.ts
+++ b/src/machinery/eventListener.ts
@@ -2,6 +2,10 @@ import {backPressesStore, loadedComponentStore, viewStore} from "../stores/store
 import Navigation from "./navigation";
 import {BACK, MENU_VIEW} from "../constants/views";
 
+export interface LoadedElements {
+    elements: HTMLElement[]
+}
+
 let selection = undefined;
 
 const elementSelector = (selectedElement) => {

--- a/src/machinery/eventListener.ts
+++ b/src/machinery/eventListener.ts
@@ -1,4 +1,4 @@
-import {loadedComponentStore, viewStore} from "../stores/stores";
+import {backPressesStore, loadedComponentStore, viewStore} from "../stores/stores";
 import Navigation from "./navigation";
 import {BACK, MENU_VIEW} from "../constants/views";
 
@@ -16,6 +16,11 @@ const unsubscribe = loadedComponentStore.subscribe((value) => {
     document.activeElement.addEventListener('keydown', handleKeydown);
 })
 
+let backPresses: (() => any)[] = []
+const unsubscribeBackPress = backPressesStore.subscribe((b: () => any) =>  {
+    backPresses.push(b)
+})
+
 export function handleKeydown(e) {
     switch (e.key) {
         case 'ArrowUp':
@@ -29,22 +34,28 @@ export function handleKeydown(e) {
             }
             break;
         case 'ArrowRight':
-            if(!!navigation.targetElement){
-                // navigationStore.set({type: HISTORY_BACK_ACTION_TYPE});
+            if(!!selection){
+                selection.click()
+                e.preventDefault();
             }else{
                 e.preventDefault();
             }
             break;
         case 'ArrowLeft':
-            if(history.data().length === 0){
+            if(backPresses.length > 0) {
+                const backPressToRun = backPresses.pop()
+                backPressToRun()
+            } else {
                 e.preventDefault();
-            }else{
-                history.back();
             }
             break;
         case 'Backspace':
-            console.log('herer')
-            viewStore.set(BACK)
+            if(backPresses.length > 0) {
+                const backPressToRun = backPresses.pop()
+                backPressToRun()
+            } else {
+                e.preventDefault();
+            }
             break;
         case 'Enter':
             if(!!selection){

--- a/src/machinery/models.ts
+++ b/src/machinery/models.ts
@@ -17,3 +17,7 @@ export interface NanoTransaction {
     type: string
     localTimestamp: string
 }
+
+export interface Balance {
+    amount: string
+}

--- a/src/machinery/models.ts
+++ b/src/machinery/models.ts
@@ -1,13 +1,13 @@
 export type NanoAddress = string
 export type Seed = string
 
-export interface Account {
+export interface NanoAccount {
     alias: string
     address: NanoAddress
 }
 
-export interface Wallet {
-    accounts: Account[]
+export interface NanoWallet {
+    accounts: NanoAccount[]
     seed: Seed
 }
 

--- a/src/machinery/nano-rpc.ts
+++ b/src/machinery/nano-rpc.ts
@@ -1,13 +1,19 @@
-import {AccountHistoryRequestActionEnum, Configuration, NodeRPCsApi} from "nano-rpc-fetch";
-import type {AccountHistoryRequest, AccountHistoryResponse} from "nano-rpc-fetch";
-import { tools } from 'nanocurrency-web'
-import type {NanoTransaction} from "./models";
+import type {AccountHistoryResponse} from "nano-rpc-fetch";
+import {
+    AccountBalanceRequestActionEnum,
+    AccountBalanceResponse,
+    AccountHistoryRequestActionEnum,
+    Configuration,
+    NodeRPCsApi
+} from "nano-rpc-fetch";
+import {tools} from 'nanocurrency-web'
+import type {Balance, NanoAddress, NanoTransaction} from "./models";
 
 const nanoApi = new NodeRPCsApi(new Configuration({
     basePath: "https://nano.mehl.no/node"
 }));
 
-export async function resolveHistory(address: string): Promise<NanoTransaction[]> {
+export async function resolveHistory(address: NanoAddress): Promise<NanoTransaction[]> {
     let history: AccountHistoryResponse = await nanoApi.accountHistory({
         accountHistoryRequest: {
             action: AccountHistoryRequestActionEnum.AccountHistory,
@@ -23,6 +29,19 @@ export async function resolveHistory(address: string): Promise<NanoTransaction[]
             localTimestamp: block.localTimestamp
         }
     })
+}
+
+export async function resolveBalance(address: NanoAddress): Promise<Balance> {
+    let balance: AccountBalanceResponse = await nanoApi.accountBalance({
+        accountBalanceRequest: {
+            action: AccountBalanceRequestActionEnum.AccountBalance,
+            account: address,
+        }
+    })
+
+    return {
+        amount: rawToNano(balance.balance, 2)
+    }
 }
 
 function rawToNano(raw: number, fractions?: number): string {

--- a/src/machinery/qr-code-generator.ts
+++ b/src/machinery/qr-code-generator.ts
@@ -1,0 +1,6 @@
+import type {NanoAddress} from "./models";
+import QRCode from 'qrcode';
+
+export async function generate(address: NanoAddress): Promise<string> {
+    return await QRCode.toDataURL(address);
+}

--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -5,3 +5,4 @@ import type {View} from "../constants/views";
 export const viewStore: Writable<View> = writable<View>(RECEIVE_VIEW);
 export const loadedComponentStore = writable({})
 
+export const backPressesStore = writable<(() => any)>(() => {})

--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -1,8 +1,10 @@
 import {Writable, writable} from 'svelte/store';
 import {RECEIVE_VIEW} from "../constants/views";
 import type {View} from "../constants/views";
+import type {LoadedElements} from "../machinery/eventListener";
 
 export const viewStore: Writable<View> = writable<View>(RECEIVE_VIEW);
-export const loadedComponentStore = writable({})
-
-export const backPressesStore = writable<(() => any)>(() => {})
+export const loadedComponentStore: Writable<LoadedElements> = writable<LoadedElements>({
+    elements: []
+})
+export const backPressesStore: Writable<() => any> = writable<(() => any)>(() => {})

--- a/src/view/Wallet.svelte
+++ b/src/view/Wallet.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+    import type {NanoAccount, NanoWallet} from "../machinery/models";
+    import Button from "../components/Button.svelte";
+    import List from "../components/List.svelte";
+    import Primary from "../components/list/Primary.svelte";
+    import Account from "./wallet/Account.svelte";
+
+    let wallet: NanoWallet = {
+        accounts: [
+            {
+                alias: "Main",
+                address: "nano_1jtx5p8141zjtukz4msp1x93st7nh475f74odj8673qqm96xczmtcnanos1o"
+            },
+            {
+                alias: "Savings",
+                address: "nano_1hzoje373eapce4ses7xsx539suww5555hi9q8i8j7hpbayzxq4c4nn91hr8"
+            }
+        ],
+        seed: "some-seed"
+    }
+    let selectedAccount: NanoAccount | undefined = undefined
+
+</script>
+
+{#if selectedAccount}
+    <Account account={selectedAccount} />
+{:else}
+    <List>
+        {#each wallet.accounts as account}
+            <Primary primaryText={account.alias} on:click={() => selectedAccount = account} />
+        {/each}
+    </List>
+    <Button languageId="generateAddress"/>
+{/if}
+

--- a/src/view/Wallet.svelte
+++ b/src/view/Wallet.svelte
@@ -4,6 +4,7 @@
     import List from "../components/List.svelte";
     import Primary from "../components/list/Primary.svelte";
     import Account from "./wallet/Account.svelte";
+    import {backPressesStore} from "../stores/stores";
 
     let wallet: NanoWallet = {
         accounts: [
@@ -20,6 +21,11 @@
     }
     let selectedAccount: NanoAccount | undefined = undefined
 
+    const selectAccount = (account: NanoAccount) => {
+        backPressesStore.set(() => selectedAccount = undefined)
+        selectedAccount = account;
+    }
+
 </script>
 
 {#if selectedAccount}
@@ -27,7 +33,7 @@
 {:else}
     <List>
         {#each wallet.accounts as account}
-            <Primary primaryText={account.alias} on:click={() => selectedAccount = account} />
+            <Primary primaryText={account.alias} on:click={() => selectAccount(account)} />
         {/each}
     </List>
     <Button languageId="generateAddress"/>

--- a/src/view/Wallet.svelte
+++ b/src/view/Wallet.svelte
@@ -5,12 +5,13 @@
     import Primary from "../components/list/Primary.svelte";
     import Account from "./wallet/Account.svelte";
     import {backPressesStore} from "../stores/stores";
+    import WithSecondary from "../components/list/WithSecondary.svelte";
 
     let wallet: NanoWallet = {
         accounts: [
             {
                 alias: "Main",
-                address: "nano_1jtx5p8141zjtukz4msp1x93st7nh475f74odj8673qqm96xczmtcnanos1o"
+                address: "nano_3niceeeyiaa86k58zhaeygxfkuzgffjtwju9ep33z9c8qekmr3iuc95jbqc8"
             },
             {
                 alias: "Savings",
@@ -33,7 +34,7 @@
 {:else}
     <List>
         {#each wallet.accounts as account}
-            <Primary primaryText={account.alias} on:click={() => selectAccount(account)} />
+            <WithSecondary primaryText={account.alias} on:click={() => selectAccount(account)} secondaryText={account.address} />
         {/each}
     </List>
     <Button languageId="generateAddress"/>

--- a/src/view/wallet/Account.svelte
+++ b/src/view/wallet/Account.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import type {NanoAccount} from "../../machinery/models";
+    import type {Balance, NanoAccount} from "../../machinery/models";
     import Seperator from "../../components/Seperator.svelte";
     import List from "../../components/List.svelte";
     import Primary from "../../components/list/Primary.svelte";
@@ -7,6 +7,8 @@
     import Send from "./Send.svelte";
     import Receive from "./Receive.svelte";
     import {backPressesStore} from "../../stores/stores";
+    import {onMount} from "svelte";
+    import {resolveBalance} from "../../machinery/nano-rpc";
 
     export let account: NanoAccount
 
@@ -18,10 +20,20 @@
         action = selectedAction
     }
 
+    let separatorText: string = account.alias
+    onMount(async () => {
+        try {
+            const balance: Balance = await resolveBalance(account.address)
+            separatorText = `${account.alias} ${balance.amount}`
+        } catch (error) {
+            console.log('error loading balance')
+        }
+    })
+
 </script>
 
 {#if action === 'menu'}
-    <Seperator languageId="actions" primaryText={account.alias}/>
+    <Seperator languageId="actions" primaryText={separatorText}/>
     <List>
         <Primary primaryLanguageId="transactions" on:click={() => selectAction('transactions') }/>
         <Primary primaryLanguageId="send" on:click={() => selectAction('send') }/>

--- a/src/view/wallet/Account.svelte
+++ b/src/view/wallet/Account.svelte
@@ -9,10 +9,11 @@
     import {backPressesStore} from "../../stores/stores";
     import {onMount} from "svelte";
     import {resolveBalance} from "../../machinery/nano-rpc";
+    import Button from "../../components/Button.svelte";
 
     export let account: NanoAccount
 
-    type AccountAction = 'menu' | 'transactions' | 'send' | 'receive'
+    type AccountAction = 'menu' | 'transactions' | 'send' | 'receive' | 'update'
     let action: AccountAction = 'menu'
 
     const selectAction = (selectedAction: AccountAction) => {
@@ -24,7 +25,7 @@
     onMount(async () => {
         try {
             const balance: Balance = await resolveBalance(account.address)
-            separatorText = `${account.alias} ${balance.amount}`
+            separatorText = `${account.alias} ${balance.amount} Nano`
         } catch (error) {
             console.log('error loading balance')
         }
@@ -38,6 +39,7 @@
         <Primary primaryLanguageId="transactions" on:click={() => selectAction('transactions') }/>
         <Primary primaryLanguageId="send" on:click={() => selectAction('send') }/>
         <Primary primaryLanguageId="receive" on:click={() => selectAction('receive') }/>
+        <Button languageId="update-button" on:click={() => selectAction('update') }/>
     </List>
 {:else if action === 'transactions'}
     <Seperator languageId="transactions" primaryText={account.alias}/>

--- a/src/view/wallet/Account.svelte
+++ b/src/view/wallet/Account.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+    import type {NanoAccount} from "../../machinery/models";
+    import Seperator from "../../components/Seperator.svelte";
+    import List from "../../components/List.svelte";
+    import Primary from "../../components/list/Primary.svelte";
+    import Transactions from "../Transactions.svelte";
+    import Send from "./Send.svelte";
+    import Receive from "./Receive.svelte";
+
+    export let account: NanoAccount
+
+    type AccountAction = 'menu' | 'transactions' | 'send' | 'receive'
+    let action: AccountAction | undefined = 'menu'
+
+</script>
+
+{#if action === 'menu'}
+    <Seperator languageId="actions" primaryText={account.alias}/>
+    <List>
+        <Primary primaryLanguageId="transactions" on:click={() => action = 'transactions' }/>
+        <Primary primaryLanguageId="send" on:click={() => action = 'send' }/>
+        <Primary primaryLanguageId="receive" on:click={() => action = 'receive' }/>
+    </List>
+{:else if action === 'transactions'}
+    <Seperator languageId="transactions" primaryText={account.alias}/>
+    <Transactions address={account.address}/>
+{:else if action === 'send'}
+    <Send />
+{:else if action === 'receive'}
+    <Receive account={account} />
+{/if}
+

--- a/src/view/wallet/Account.svelte
+++ b/src/view/wallet/Account.svelte
@@ -6,20 +6,26 @@
     import Transactions from "../Transactions.svelte";
     import Send from "./Send.svelte";
     import Receive from "./Receive.svelte";
+    import {backPressesStore} from "../../stores/stores";
 
     export let account: NanoAccount
 
     type AccountAction = 'menu' | 'transactions' | 'send' | 'receive'
-    let action: AccountAction | undefined = 'menu'
+    let action: AccountAction = 'menu'
+
+    const selectAction = (selectedAction: AccountAction) => {
+        backPressesStore.set(() => action = 'menu')
+        action = selectedAction
+    }
 
 </script>
 
 {#if action === 'menu'}
     <Seperator languageId="actions" primaryText={account.alias}/>
     <List>
-        <Primary primaryLanguageId="transactions" on:click={() => action = 'transactions' }/>
-        <Primary primaryLanguageId="send" on:click={() => action = 'send' }/>
-        <Primary primaryLanguageId="receive" on:click={() => action = 'receive' }/>
+        <Primary primaryLanguageId="transactions" on:click={() => selectAction('transactions') }/>
+        <Primary primaryLanguageId="send" on:click={() => selectAction('send') }/>
+        <Primary primaryLanguageId="receive" on:click={() => selectAction('receive') }/>
     </List>
 {:else if action === 'transactions'}
     <Seperator languageId="transactions" primaryText={account.alias}/>

--- a/src/view/wallet/Receive.svelte
+++ b/src/view/wallet/Receive.svelte
@@ -1,10 +1,24 @@
 <script lang="ts">
     import type {NanoAccount} from "../../machinery/models";
+    import {onMount} from "svelte";
+    import {generate} from "../../machinery/qr-code-generator";
 
     export let account: NanoAccount;
+    let dataUrl: string | undefined = undefined
+
+    onMount(async () => {
+        dataUrl = await generate(account.address)
+    })
 </script>
 
 <div id="receive__view">
+
+    {#if dataUrl}
+        <img src={dataUrl} alt={account.address} />
+    {:else}
+        <span data-l10n-id="receive-loading-qr"></span>
+    {/if}
+
 
     <span>{account.alias}</span>
     <span>{account.address}</span>

--- a/src/view/wallet/Receive.svelte
+++ b/src/view/wallet/Receive.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+    import type {NanoAccount} from "../../machinery/models";
+
+    export let account: NanoAccount;
+</script>
+
+<div id="receive__view">
+
+    <span>{account.alias}</span>
+    <span>{account.address}</span>
+</div>
+

--- a/src/view/wallet/Receive.svelte
+++ b/src/view/wallet/Receive.svelte
@@ -19,7 +19,6 @@
         <span data-l10n-id="receive-loading-qr"></span>
     {/if}
 
-
     <span>{account.alias}</span>
     <span>{account.address}</span>
 </div>

--- a/src/view/wallet/Send.svelte
+++ b/src/view/wallet/Send.svelte
@@ -1,0 +1,20 @@
+<script>
+    import QRcode from "../send/QRcode.svelte";
+    import Input from "../send/Input.svelte";
+    import Seperator from "../../components/Seperator.svelte";
+    import List from "../../components/List.svelte";
+    import Primary from "../../components/list/Primary.svelte";
+
+    let selectedSend = undefined;
+</script>
+<Seperator languageId="send-select" />
+{#if selectedSend === 'qr'}
+    <QRcode />
+{:else if selectedSend === 'input'}
+    <Input />
+{:else}
+    <List>
+        <Primary primaryText="Send by QR code" on:click={() => selectedSend = "qr"}/>
+        <Primary primaryText="Send by address" on:click={() => selectedSend = "input"}/>
+    </List>
+{/if}

--- a/src/view/wallet/Send.svelte
+++ b/src/view/wallet/Send.svelte
@@ -1,11 +1,12 @@
-<script>
+<script lang="ts">
     import QRcode from "../send/QRcode.svelte";
     import Input from "../send/Input.svelte";
     import Seperator from "../../components/Seperator.svelte";
     import List from "../../components/List.svelte";
     import Primary from "../../components/list/Primary.svelte";
 
-    let selectedSend = undefined;
+    type SendAction = 'qr' | 'input'
+    let selectedSend: SendAction | undefined = undefined;
 </script>
 <Seperator languageId="send-select" />
 {#if selectedSend === 'qr'}


### PR DESCRIPTION
Tries to implement wallet navigation as talked about in #10. Also adds basic "back" and "forward" navigation as talked about in #4. Still a very basic UI for this. Went a bit overboard on this and implemented balance API and QR code as well (had it available in my previous kaios-wallet thingy).
 
Copied send/receive views into the wallet-views folder. If we move forward with this we can delete those on the "top level" and add a menu→send flow.

![nano-kaois-1](https://user-images.githubusercontent.com/788059/100539254-933f8080-3235-11eb-8bd9-e0cb53ffcb20.gif)
