### PR TITLE
Adds camera capture for scanning QR codes

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
   },
   "dependencies": {
     "crypto-js": "^4.0.0",
+    "image-capture": "^0.4.0",
+    "jsqr": "^1.3.1",
     "nano-rpc-fetch": "^1.0.0",
     "nanocurrency-web": "^1.2.2",
     "qrcode": "^1.4.4",

--- a/public/locales/en-US.properties
+++ b/public/locales/en-US.properties
@@ -31,6 +31,7 @@ send-amount = Amount
 send-button = Send
 send-max-button = Max
 send-scan-qr = Scan QR code
+qr-capture-image = Capture QR code
 
 
 #QRCode Send

--- a/public/locales/en-US.properties
+++ b/public/locales/en-US.properties
@@ -58,3 +58,6 @@ create-new-wallet = Create new
 wallet-mnemonic = Mnemonic
 wallet-seed = Seed
 wallet-password = Set a password for your wallet
+
+# Soft keys
+softkey-capture-camera = Capture QR

--- a/public/locales/en-US.properties
+++ b/public/locales/en-US.properties
@@ -30,6 +30,7 @@ send-address = Address
 send-amount = Amount
 send-button = Send
 send-max-button = Max
+send-scan-qr = Scan QR code
 
 
 #QRCode Send

--- a/public/manifest.webapp
+++ b/public/manifest.webapp
@@ -2,7 +2,7 @@
   "version": "1.0.0",
   "name": "Nano cryptocurrency wallet",
   "description": "Nano is a feeless cryptocurrency. A secure and fast way to transfer money across borders.",
-  "type": "web",
+  "type": "privileged",
   "launch_path": "/index.html",
   "icons": {
     "56": "/assets/icons/kaios_56.png",
@@ -13,6 +13,17 @@
     "name": "Philipp Blum",
     "url": "https://www.facebook.com/Philipp-Blum-100785578393066"
   },
+  "permissions": {
+    "systemXHR": {},
+    "camera": {
+      "description": "Required for scanning QR codes"
+    },
+    "video-capture": {
+      "description": "Required for scanning QR codes"
+    }
+  },
+  "fullscreen": "true",
+  "orientation": "default",
   "locales": {
     "en-US": {
       "name": "Nano cryptocurrency wallet",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -10,6 +10,7 @@
 	import UnlockWallet from "./view/UnlockWallet.svelte";
 	import CreateWallet from "./view/CreateWallet.svelte";
 	import {walletDataExists} from "./machinery/secure-storage";
+	import SoftwareKeys from "./view/SoftwareKeys.svelte";
 
 	let header: string | undefined = undefined
 	let view: string | undefined = undefined
@@ -21,15 +22,12 @@
 	});
 
 	onMount(() => {
-		if(walletDataExists()) {
+		if (walletDataExists()) {
 			pushMenu('unlock')
 		} else {
 			pushMenu('create')
 		}
 	})
-
-	const toggleMenu = () => pushMenu('menu')
-
 </script>
 
 <main>
@@ -48,10 +46,5 @@
 			<CreateWallet />
 		{/if}
 	</div>
-
-	<div class="kui-software-key">
-		<h5 role="button" class="kui-h5 kui-text-left" id="kui-left-soft-key"></h5>
-		<h5 role="button" class="kui-h5 kui-text-center kui-text-upcase" id="kui-middle-soft-key"></h5>
-		<h5 role="button" class="kui-h5 kui-text-right" on:click={toggleMenu} data-l10n-id="rightNavButton"></h5>
-	</div>
+	<SoftwareKeys/>
 </main>

--- a/src/components/CameraCapture.svelte
+++ b/src/components/CameraCapture.svelte
@@ -19,7 +19,10 @@
         video.srcObject = videoPreview
         await video.play()
         softwareKeysStore.set({
-            middleKey: () => captureCameraImage()
+            middleKey: {
+                onClick: () => captureCameraImage(),
+                languageId: "softkey-capture-camera"
+            },
         })
     }
 

--- a/src/components/CameraCapture.svelte
+++ b/src/components/CameraCapture.svelte
@@ -5,6 +5,7 @@
     import jsQR, {QRCode} from "jsqr";
     import type {NanoAddress} from "../machinery/models";
     import {tools} from "nanocurrency-web";
+    import {softwareKeysStore} from "../stores/stores";
 
     export let scannedAddress: (address: NanoAddress) => void
 
@@ -17,11 +18,19 @@
         const video: HTMLVideoElement = document.querySelector('#video');
         video.srcObject = videoPreview
         await video.play()
+        softwareKeysStore.set({
+            middleKey: () => captureCameraImage()
+        })
     }
 
     const stopRecording = () => {
-        const track: MediaStreamTrack | undefined = videoPreview.getVideoTracks()[0]
-        track?.stop()
+        const tracks: MediaStreamTrack[] | undefined = videoPreview.getVideoTracks()
+        tracks.forEach(track => {
+            track.stop()
+        })
+        softwareKeysStore.set({
+            middleKey: undefined
+        })
     }
 
     const captureCameraImage = async () => {
@@ -41,6 +50,7 @@
             context.drawImage(frame, 0, 0, frame.width, frame.height);
             const imageData: ImageData = context.getImageData(0, 0, frame.width, frame.height)
             await decodeImage(imageData)
+            track.stop();
         } catch (e) {
             console.log(e)
         }
@@ -75,7 +85,5 @@
         height: auto;
     }
 </style>
-
 <canvas id="canvas" height={0} width={0} hidden={showVideo} class="video-el"/>
 <video id="video" autoplay hidden={!showVideo} class="video-el"/>
-<Button languageId="qr-capture-image" on:click={captureCameraImage}></Button>

--- a/src/components/CameraCapture.svelte
+++ b/src/components/CameraCapture.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+    import {ImageCapture} from 'image-capture'
+    import {onDestroy, onMount} from "svelte";
+    import Button from "./Button.svelte";
+    import jsQR, {QRCode} from "jsqr";
+    import type {NanoAddress} from "../machinery/models";
+    import {tools} from "nanocurrency-web";
+
+    export let scannedAddress: (address: NanoAddress) => void
+
+    let videoPreview: MediaStream | undefined
+    let showVideo: boolean = true
+
+    const startRecording = async () => {
+        showVideo = true
+        videoPreview = await navigator.mediaDevices.getUserMedia({video: true})
+        const video: HTMLVideoElement = document.querySelector('#video');
+        video.srcObject = videoPreview
+        await video.play()
+    }
+
+    const stopRecording = () => {
+        const track: MediaStreamTrack | undefined = videoPreview.getVideoTracks()[0]
+        track?.stop()
+    }
+
+    const captureCameraImage = async () => {
+        try {
+            showVideo = false;
+            const track = videoPreview.getVideoTracks()[0];
+            let imageCapture = new ImageCapture(track);
+            const frame = await imageCapture.grabFrame();
+            const canvas: HTMLCanvasElement = document.querySelector('#canvas');
+
+            // set canvas dimensions to video ones to not truncate picture
+            canvas.width = frame.width;
+            canvas.height = frame.height;
+
+            // copy full video frame into the canvas
+            let context = canvas.getContext('2d');
+            context.drawImage(frame, 0, 0, frame.width, frame.height);
+            const imageData: ImageData = context.getImageData(0, 0, frame.width, frame.height)
+            await decodeImage(imageData)
+        } catch (e) {
+            console.log(e)
+        }
+    }
+
+    const decodeImage = async (imageData) => {
+        try {
+            const code: QRCode | null = jsQR(imageData.data, imageData.width, imageData.height);
+            if (code && tools.validateAddress(code.data)) {
+                stopRecording();
+                scannedAddress(code.data)
+            } else {
+                await startRecording();
+            }
+        } catch (e) {
+            console.log(e)
+        }
+    }
+
+    onMount(async () => {
+        await startRecording()
+    })
+
+    onDestroy(() => {
+        stopRecording();
+    })
+</script>
+
+<style>
+    .video-el {
+        width: 100%;
+        height: auto;
+    }
+</style>
+
+<canvas id="canvas" height={0} width={0} hidden={showVideo} class="video-el"/>
+<video id="video" autoplay hidden={!showVideo} class="video-el"/>
+<Button languageId="qr-capture-image" on:click={captureCameraImage}></Button>

--- a/src/machinery/NavigationState.ts
+++ b/src/machinery/NavigationState.ts
@@ -9,6 +9,8 @@ export type MenuSelector =
   | 'create';
 export type AccountAction = 'send' | 'transactions' | 'receive';
 
+export type SendAction = 'qr' | 'address';
+
 export interface SelectedAccountState {
   selectedAccount: NanoAccount;
   view: AccountAction | undefined;

--- a/src/machinery/SoftwareKeysState.ts
+++ b/src/machinery/SoftwareKeysState.ts
@@ -1,3 +1,8 @@
+export interface SoftKey {
+  onClick: () => void;
+  languageId: string;
+}
+
 export interface SoftwareKeysState {
-  middleKey: (() => void) | undefined;
+  middleKey: SoftKey | undefined;
 }

--- a/src/machinery/SoftwareKeysState.ts
+++ b/src/machinery/SoftwareKeysState.ts
@@ -1,0 +1,3 @@
+export interface SoftwareKeysState {
+  middleKey: (() => void) | undefined;
+}

--- a/src/machinery/eventListener.ts
+++ b/src/machinery/eventListener.ts
@@ -53,7 +53,6 @@ export function popState(): boolean {
     return false;
   }
 }
-
 export function pushMenu(menu: MenuSelector): void {
   pushState({ ...stateHistory[index], menu });
 }
@@ -68,6 +67,9 @@ export function pushState(state: NavigationState): void {
   if (state.menu === 'menu' && stateHistory[index].menu === 'menu') {
     popState();
     return;
+  } else if (state.menu === 'unlock') {
+    stateHistory = [];
+    index = 0;
   }
 
   index++;

--- a/src/machinery/eventListener.ts
+++ b/src/machinery/eventListener.ts
@@ -30,7 +30,7 @@ loadedComponentStore.subscribe((value) => {
 let middleKey: (() => void) | undefined = undefined;
 
 softwareKeysStore.subscribe((value: SoftwareKeysState) => {
-  middleKey = value.middleKey;
+  middleKey = value.middleKey?.onClick;
 });
 
 let stateHistory: NavigationState[] = [

--- a/src/machinery/eventListener.ts
+++ b/src/machinery/eventListener.ts
@@ -1,6 +1,11 @@
-import { loadedComponentStore, navigationStore } from '../stores/stores';
+import {
+  loadedComponentStore,
+  navigationStore,
+  softwareKeysStore,
+} from '../stores/stores';
 import { Navigation } from './navigation';
 import type { MenuSelector, NavigationState } from './NavigationState';
+import type { SoftwareKeysState } from './SoftwareKeysState';
 
 export interface LoadedElements {
   elements: any;
@@ -20,6 +25,12 @@ loadedComponentStore.subscribe((value) => {
     document.addEventListener('keydown', handleKeydown);
     navigation.focus();
   }
+});
+
+let middleKey: (() => void) | undefined = undefined;
+
+softwareKeysStore.subscribe((value: SoftwareKeysState) => {
+  middleKey = value.middleKey;
 });
 
 let stateHistory: NavigationState[] = [
@@ -98,7 +109,10 @@ export function handleKeydown(e) {
       }
       break;
     case 'Enter':
-      if (selection) {
+      if (middleKey) {
+        middleKey();
+        e.preventDefault();
+      } else if (selection) {
         selection.click();
         e.preventDefault();
       } else {

--- a/src/machinery/secure-storage.ts
+++ b/src/machinery/secure-storage.ts
@@ -87,5 +87,5 @@ function storage(SECRET_KEY: string): SecureStorage {
 }
 
 export function walletDataExists(): boolean {
-  return localStorage.getItem(WALLET_STORE) !== undefined;
+  return localStorage.getItem(WALLET_STORE) !== null;
 }

--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -1,6 +1,7 @@
 import { Writable, writable } from 'svelte/store';
 import type { LoadedElements } from '../machinery/eventListener';
 import type { NavigationState } from '../machinery/NavigationState';
+import type { SoftwareKeysState } from '../machinery/SoftwareKeysState';
 
 export const loadedComponentStore: Writable<LoadedElements> = writable<LoadedElements>(
   {
@@ -12,4 +13,8 @@ export const navigationStore: Writable<NavigationState> = writable({
   menu: 'wallet',
   account: undefined,
   wallet: undefined,
+});
+
+export const softwareKeysStore: Writable<SoftwareKeysState> = writable({
+  middleKey: undefined,
 });

--- a/src/view/SoftwareKeys.svelte
+++ b/src/view/SoftwareKeys.svelte
@@ -1,11 +1,30 @@
 <script lang="ts">
     import {pushMenu} from "../machinery/eventListener";
+    import {softwareKeysStore} from "../stores/stores";
 
     const toggleMenu = () => pushMenu('menu')
+
+    let middleKeyLanguageId: string | undefined = undefined
+    let middleOnClick: (() => void) | undefined = undefined
+
+    softwareKeysStore.subscribe(value => {
+        if(value.middleKey) {
+            middleKeyLanguageId = "softkey-capture-camera"
+            middleOnClick = value.middleKey
+        } else if(value.middleKey === undefined) {
+            middleKeyLanguageId = undefined;
+            middleOnClick = undefined
+        }
+    })
+
 </script>
 
 <div class="kui-software-key">
     <h5 role="button" class="kui-h5 kui-text-left" id="kui-left-soft-key"></h5>
-    <h5 role="button" class="kui-h5 kui-text-center kui-text-upcase" id="kui-middle-soft-key"></h5>
+    {#if middleKeyLanguageId}
+        <h5 role="button" class="kui-h5 kui-text-center kui-text-upcase" on:click={middleOnClick} data-l10n-id={middleKeyLanguageId}></h5>
+    {:else}
+        <h5 role="button" class="kui-h5 kui-text-center kui-text-upcase"></h5>
+    {/if}
     <h5 role="button" class="kui-h5 kui-text-right" on:click={toggleMenu} data-l10n-id="rightNavButton"></h5>
 </div>

--- a/src/view/SoftwareKeys.svelte
+++ b/src/view/SoftwareKeys.svelte
@@ -8,13 +8,8 @@
     let middleOnClick: (() => void) | undefined = undefined
 
     softwareKeysStore.subscribe(value => {
-        if(value.middleKey) {
-            middleKeyLanguageId = "softkey-capture-camera"
-            middleOnClick = value.middleKey
-        } else if(value.middleKey === undefined) {
-            middleKeyLanguageId = undefined;
-            middleOnClick = undefined
-        }
+        middleKeyLanguageId = value.middleKey?.languageId
+        middleOnClick = value.middleKey?.onClick
     })
 
 </script>

--- a/src/view/SoftwareKeys.svelte
+++ b/src/view/SoftwareKeys.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+    import {pushMenu} from "../machinery/eventListener";
+
+    const toggleMenu = () => pushMenu('menu')
+</script>
+
+<div class="kui-software-key">
+    <h5 role="button" class="kui-h5 kui-text-left" id="kui-left-soft-key"></h5>
+    <h5 role="button" class="kui-h5 kui-text-center kui-text-upcase" id="kui-middle-soft-key"></h5>
+    <h5 role="button" class="kui-h5 kui-text-right" on:click={toggleMenu} data-l10n-id="rightNavButton"></h5>
+</div>

--- a/src/view/send/QRcode.svelte
+++ b/src/view/send/QRcode.svelte
@@ -1,3 +1,0 @@
-<div class="kui-header">
-    <h1 class="kui-h1">QR</h1>
-</div>

--- a/src/view/send/SendByAddress.svelte
+++ b/src/view/send/SendByAddress.svelte
@@ -2,10 +2,12 @@
     import LabelledInput from "../../components/LabelledInput.svelte";
     import Button from "../../components/Button.svelte";
     import type {NanoAddress, NANO, NanoAccount, RAW} from "../../machinery/models";
+    import type {SendAction} from "../../machinery/NavigationState";
     import {tools} from "nanocurrency-web";
     import {sendNano} from "../../machinery/nano-ops";
     import {nanoToRaw, rawToNano} from "../../machinery/nanocurrency-web-wrapper";
 
+    export let sendType: SendAction;
     export let account: NanoAccount;
     export let balance: RAW;
 
@@ -39,9 +41,17 @@
         }
     }
 
+    const scanQRCode = () => {
+
+    }
+
 </script>
 
-<LabelledInput languageId="send-address" type="text" on:change={setAddress}/>
+{#if sendType === 'address'}
+    <LabelledInput languageId="send-address" type="text" on:change={setAddress}/>
+{:else}
+    <Button languageId="send-scan-qr" on:click={scanQRCode} />
+{/if}
 <LabelledInput languageId="send-amount" type="text" on:change={setAmount} bind:value={balanceValue}/>
 <Button languageId="send-max-button" on:click={setMax}/>
 <Button languageId="send-button" on:click={send}/>

--- a/src/view/send/SendByAddress.svelte
+++ b/src/view/send/SendByAddress.svelte
@@ -6,6 +6,7 @@
     import {tools} from "nanocurrency-web";
     import {sendNano} from "../../machinery/nano-ops";
     import {nanoToRaw, rawToNano} from "../../machinery/nanocurrency-web-wrapper";
+    import CameraCapture from "../../components/CameraCapture.svelte";
 
     export let sendType: SendAction;
     export let account: NanoAccount;
@@ -14,10 +15,11 @@
     let toAddress: NanoAddress | undefined
     let sendAmount: NANO | undefined
     let balanceValue: string | undefined = undefined
+    let showCamera: boolean = false
 
     const setAddress = (event) => {
         const address = event.target.value;
-        if(tools.validateAddress(address)) {
+        if (tools.validateAddress(address)) {
             toAddress = address
         }
     }
@@ -25,8 +27,8 @@
     const setAmount = (event) => {
         let strAmount: string = event.target.value;
         const amount: number = Number.parseFloat(strAmount);
-        if(!isNaN(amount)) {
-            sendAmount = { amount: strAmount }
+        if (!isNaN(amount)) {
+            sendAmount = {amount: strAmount}
         }
     }
 
@@ -36,21 +38,29 @@
     }
 
     const send = async () => {
-        if(toAddress && sendAmount) {
+        if (toAddress && sendAmount) {
             await sendNano(account, toAddress, nanoToRaw(sendAmount), balance)
         }
     }
 
-    const scanQRCode = () => {
+    const scanQRCode = () => showCamera = true
 
+    const scannedAddress = (address: NanoAddress) => {
+        toAddress = address;
+        showCamera = false;
+        sendType = 'address'
     }
 
 </script>
 
 {#if sendType === 'address'}
-    <LabelledInput languageId="send-address" type="text" on:change={setAddress}/>
+    <LabelledInput languageId="send-address" type="text" on:change={setAddress} value={toAddress}/>
 {:else}
-    <Button languageId="send-scan-qr" on:click={scanQRCode} />
+    {#if showCamera}
+        <CameraCapture scannedAddress={scannedAddress}/>
+    {:else}
+        <Button languageId="send-scan-qr" on:click={scanQRCode} />
+    {/if}
 {/if}
 <LabelledInput languageId="send-amount" type="text" on:change={setAmount} bind:value={balanceValue}/>
 <Button languageId="send-max-button" on:click={setMax}/>

--- a/src/view/send/SendByAddress.svelte
+++ b/src/view/send/SendByAddress.svelte
@@ -7,6 +7,7 @@
     import {sendNano} from "../../machinery/nano-ops";
     import {nanoToRaw, rawToNano} from "../../machinery/nanocurrency-web-wrapper";
     import CameraCapture from "../../components/CameraCapture.svelte";
+    import {onMount} from "svelte";
 
     export let sendType: SendAction;
     export let account: NanoAccount;
@@ -15,7 +16,7 @@
     let toAddress: NanoAddress | undefined
     let sendAmount: NANO | undefined
     let balanceValue: string | undefined = undefined
-    let showCamera: boolean = false
+    let showCamera: boolean = sendType === 'qr'
 
     const setAddress = (event) => {
         const address = event.target.value;
@@ -43,8 +44,6 @@
         }
     }
 
-    const scanQRCode = () => showCamera = true
-
     const scannedAddress = (address: NanoAddress) => {
         toAddress = address;
         showCamera = false;
@@ -53,15 +52,11 @@
 
 </script>
 
-{#if sendType === 'address'}
-    <LabelledInput languageId="send-address" type="text" on:change={setAddress} value={toAddress}/>
+{#if sendType === 'qr' && showCamera}
+    <CameraCapture scannedAddress={scannedAddress}/>
 {:else}
-    {#if showCamera}
-        <CameraCapture scannedAddress={scannedAddress}/>
-    {:else}
-        <Button languageId="send-scan-qr" on:click={scanQRCode} />
-    {/if}
+    <LabelledInput languageId="send-address" type="text" on:change={setAddress} value={toAddress}/>
+    <LabelledInput languageId="send-amount" type="text" on:change={setAmount} bind:value={balanceValue}/>
+    <Button languageId="send-max-button" on:click={setMax}/>
+    <Button languageId="send-button" on:click={send}/>
 {/if}
-<LabelledInput languageId="send-amount" type="text" on:change={setAmount} bind:value={balanceValue}/>
-<Button languageId="send-max-button" on:click={setMax}/>
-<Button languageId="send-button" on:click={send}/>

--- a/src/view/wallet/Send.svelte
+++ b/src/view/wallet/Send.svelte
@@ -6,7 +6,6 @@
     import type { NanoAccount, RAW } from "../../machinery/models";
     import type {SendAction } from "../../machinery/NavigationState";
 
-
     let selectedSend: SendAction | undefined = undefined;
 
     export let account: NanoAccount;

--- a/src/view/wallet/Send.svelte
+++ b/src/view/wallet/Send.svelte
@@ -1,25 +1,24 @@
 <script lang="ts">
-    import QRcode from "../send/QRcode.svelte";
     import SendByAddress from "../send/SendByAddress.svelte";
     import Seperator from "../../components/Seperator.svelte";
     import List from "../../components/List.svelte";
     import Primary from "../../components/list/Primary.svelte";
     import type { NanoAccount, RAW } from "../../machinery/models";
+    import type {SendAction } from "../../machinery/NavigationState";
 
-    type SendAction = 'qr' | 'input'
+
     let selectedSend: SendAction | undefined = undefined;
 
     export let account: NanoAccount;
     export let balance: RAW;
 </script>
 <Seperator languageId="send-select" />
-{#if selectedSend === 'qr'}
-    <QRcode />
-{:else if selectedSend === 'input'}
-    <SendByAddress account={account} balance={balance}/>
+
+{#if selectedSend}
+    <SendByAddress account={account} balance={balance} sendType={selectedSend}/>
 {:else}
     <List>
         <Primary primaryText="Send by QR code" on:click={() => selectedSend = "qr"}/>
-        <Primary primaryText="Send by address" on:click={() => selectedSend = "input"}/>
+        <Primary primaryText="Send by address" on:click={() => selectedSend = "address"}/>
     </List>
 {/if}


### PR DESCRIPTION
This closes #42 

Changes:

- App must be "privileged" to use the camera and capture images in KaiOS
- Depends on two new libraries, one as polyfill for camera capture, the other for decoding a QR code from captured image
- Adds means of setting "software keys" from different parts on the flow, reason for this was to use middle button as "capture button" in QR code, as I wanted most of the screen to be the video preview