### PR TITLE
Loads all accounts at once, clean state a bit

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
-	import {loadedComponentStore, navigationStore} from "./stores/stores";
+	import { navigationStore } from "./stores/stores";
+	import type {NavigationState} from "./machinery/NavigationState";
 	import Menu from "./view/Menu.svelte";
-	import {onMount} from "svelte";
-	import {pushMenu} from "./machinery/eventListener";
 	import Setup from "./view/Setup.svelte";
 	import About from "./view/About.svelte";
 	import Wallet from "./view/Wallet.svelte";
-	import type {NavigationState} from "./machinery/NavigationState";
 	import UnlockWallet from "./view/UnlockWallet.svelte";
 	import CreateWallet from "./view/CreateWallet.svelte";
 	import SoftwareKeys from "./view/SoftwareKeys.svelte";
@@ -19,10 +17,6 @@
 	const unsubscribe = navigationStore.subscribe<NavigationState>(value => {
 		state = value
 	});
-
-	onMount(() => {
-		pushMenu('unlock')
-	})
 </script>
 
 <main>

--- a/src/machinery/NavigationState.ts
+++ b/src/machinery/NavigationState.ts
@@ -22,3 +22,9 @@ export interface NavigationState {
   account: SelectedAccountState | undefined;
   wallet: NanoWallet | undefined;
 }
+
+export const START_STATE: NavigationState = {
+  menu: 'unlock',
+  account: undefined,
+  wallet: undefined,
+};

--- a/src/machinery/eventListener.ts
+++ b/src/machinery/eventListener.ts
@@ -74,7 +74,6 @@ export function pushState(state: NavigationState): void {
   } else {
     stateHistory.push(state);
   }
-  console.log(stateHistory);
   navigationStore.set(state);
 }
 

--- a/src/machinery/eventListener.ts
+++ b/src/machinery/eventListener.ts
@@ -6,6 +6,7 @@ import {
 import { Navigation } from './navigation';
 import type { MenuSelector, NavigationState } from './NavigationState';
 import type { SoftwareKeysState } from './SoftwareKeysState';
+import { START_STATE } from './NavigationState';
 
 export interface LoadedElements {
   elements: any;
@@ -33,13 +34,7 @@ softwareKeysStore.subscribe((value: SoftwareKeysState) => {
   middleKey = value.middleKey?.onClick;
 });
 
-let stateHistory: NavigationState[] = [
-  {
-    menu: 'wallet',
-    account: undefined,
-    wallet: undefined,
-  },
-];
+let stateHistory: NavigationState[] = [START_STATE];
 
 let index = 0;
 
@@ -62,22 +57,24 @@ export function patchState(state: NavigationState): void {
   navigationStore.set(state);
 }
 
+export function clearState(): void {
+  stateHistory = [];
+  index = 0;
+}
+
 export function pushState(state: NavigationState): void {
   /** Ignore if previous state was menu and we are pushing menu */
   if (state.menu === 'menu' && stateHistory[index].menu === 'menu') {
     popState();
     return;
-  } else if (state.menu === 'unlock') {
-    stateHistory = [];
-    index = -1;
   }
-
   index++;
   if (stateHistory.length > index) {
     stateHistory[index] = state;
   } else {
     stateHistory.push(state);
   }
+  console.log(stateHistory);
   navigationStore.set(state);
 }
 

--- a/src/machinery/models.ts
+++ b/src/machinery/models.ts
@@ -9,6 +9,7 @@ export interface NanoAccount {
   address: NanoAddress;
   publicKey: PrivateKey;
   privateKey: PrivateKey;
+  balance: RAW | undefined;
 }
 
 export interface NanoWallet {

--- a/src/machinery/nano-ops.ts
+++ b/src/machinery/nano-ops.ts
@@ -1,9 +1,14 @@
-import type { BlockInfo, PendingBlock } from 'nano-rpc-fetch';
+import type {
+  BlockInfo,
+  PendingBlock,
+  AccountBalanceResponse,
+} from 'nano-rpc-fetch';
 import type { SignedBlock } from 'nanocurrency-web/dist/lib/block-signer';
 import type {
   Frontier,
   NanoAccount,
   NanoAddress,
+  NanoWallet,
   PrivateKey,
   PublicKey,
   RAW,
@@ -14,6 +19,7 @@ import {
   loadBlocks,
   loadFrontiers,
   processSimple,
+  resolveBalances,
 } from './nano-rpc-fetch-wrapper';
 import { signReceiveBlock, signSendBlock } from './nanocurrency-web-wrapper';
 
@@ -100,4 +106,20 @@ export async function sendNano(
   } catch (error) {
     console.log(error);
   }
+}
+
+export async function updateWalletAccounts(
+  wallet: NanoWallet
+): Promise<NanoWallet> {
+  const addresses = wallet.accounts.map((a) => a.address);
+  const balances: {
+    [address: string]: AccountBalanceResponse;
+  } = await resolveBalances(addresses);
+  wallet.accounts = wallet.accounts.map((a) => {
+    return {
+      ...a,
+      balance: { raw: balances[a.address].balance.toString() },
+    };
+  });
+  return wallet;
 }

--- a/src/machinery/nano-rpc-fetch-wrapper.ts
+++ b/src/machinery/nano-rpc-fetch-wrapper.ts
@@ -1,24 +1,26 @@
-import type { Frontier, RAW, NanoAddress, NanoTransaction } from './models';
+import type { Frontier, NanoAddress, NanoTransaction, RAW } from './models';
 import {
   AccountBalanceRequestActionEnum,
   AccountBalanceResponse,
   AccountHistoryRequestActionEnum,
   AccountHistoryResponse,
+  AccountsBalancesRequestActionEnum,
+  AccountsBalancesResponse,
   AccountsFrontiersRequestActionEnum,
   AccountsFrontiersResponse,
   AccountsPendingRequestActionEnum,
   AccountsPendingResponse,
+  BlockInfo,
   BlocksInfoRequestActionEnum,
   BlocksInfoResponse,
   Configuration,
   ModelBoolean,
   NodeRPCsApi,
+  PendingBlock,
   ProcessRequestActionEnum,
   ProcessResponse,
   WorkGenerateRequestActionEnum,
   WorkGenerateResponse,
-  BlockInfo,
-  PendingBlock,
 } from 'nano-rpc-fetch';
 
 const nanoApi = new NodeRPCsApi(
@@ -35,6 +37,18 @@ export async function resolveBalance(address: NanoAddress): Promise<RAW> {
     },
   });
   return { raw: balance.balance.toString() };
+}
+
+export async function resolveBalances(
+  addresses: NanoAddress[]
+): Promise<{ [address: string]: AccountBalanceResponse }> {
+  let response: AccountsBalancesResponse = await nanoApi.accountsBalances({
+    accountsBalancesRequest: {
+      action: AccountsBalancesRequestActionEnum.AccountsBalances,
+      accounts: addresses.map((a) => a),
+    },
+  });
+  return response.balances;
 }
 
 export async function processSimple(block: any): Promise<ProcessResponse> {

--- a/src/machinery/wallet.ts
+++ b/src/machinery/wallet.ts
@@ -28,6 +28,7 @@ export async function createWallet(
         address: undefined,
         privateKey: undefined,
         publicKey: undefined,
+        balance: undefined,
       },
     ],
   };
@@ -49,6 +50,7 @@ export async function addNanoAccount(
         alias: undefined,
         privateKey: nextAccount.privateKey,
         publicKey: nextAccount.publicKey,
+        balance: undefined, // TODO: Fetch balance?
       },
     ],
   };

--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -2,6 +2,7 @@ import { Writable, writable } from 'svelte/store';
 import type { LoadedElements } from '../machinery/eventListener';
 import type { NavigationState } from '../machinery/NavigationState';
 import type { SoftwareKeysState } from '../machinery/SoftwareKeysState';
+import { START_STATE } from '../machinery/NavigationState';
 
 export const loadedComponentStore: Writable<LoadedElements> = writable<LoadedElements>(
   {
@@ -9,11 +10,7 @@ export const loadedComponentStore: Writable<LoadedElements> = writable<LoadedEle
   }
 );
 
-export const navigationStore: Writable<NavigationState> = writable({
-  menu: 'wallet',
-  account: undefined,
-  wallet: undefined,
-});
+export const navigationStore: Writable<NavigationState> = writable(START_STATE);
 
 export const softwareKeysStore: Writable<SoftwareKeysState> = writable({
   middleKey: undefined,

--- a/src/view/UnlockWallet.svelte
+++ b/src/view/UnlockWallet.svelte
@@ -15,7 +15,6 @@
     }
 
     const unlock = async () => {
-        console.log('herer')
         showLoader = true;
         const data: NanoWallet | undefined = await unlockWallet(inputPhrase)
         if (data) {

--- a/src/view/UnlockWallet.svelte
+++ b/src/view/UnlockWallet.svelte
@@ -2,7 +2,7 @@
     import Content from "../components/Content.svelte";
     import LabelledInput from "../components/LabelledInput.svelte";
     import Button from "../components/Button.svelte";
-    import {pushMenu, pushState} from "../machinery/eventListener";
+    import {clearState, pushMenu, pushState} from "../machinery/eventListener";
     import type {NanoWallet} from "../machinery/models";
     import {unlockWallet} from "../machinery/secure-storage";
     import LabelledLoader from "../components/LabelledLoader.svelte";
@@ -15,9 +15,11 @@
     }
 
     const unlock = async () => {
+        console.log('herer')
         showLoader = true;
         const data: NanoWallet | undefined = await unlockWallet(inputPhrase)
         if (data) {
+            clearState()
             pushState({menu: 'wallet', wallet: data, account: undefined})
         }
         showLoader = false;

--- a/src/view/wallet/Account.svelte
+++ b/src/view/wallet/Account.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import type {NANO, NanoAccount, NanoWallet, RAW} from "../../machinery/models";
+    import type {NanoAccount, NanoWallet} from "../../machinery/models";
     import Seperator from "../../components/Seperator.svelte";
     import List from "../../components/List.svelte";
     import Primary from "../../components/list/Primary.svelte";
@@ -7,11 +7,9 @@
     import Send from "./Send.svelte";
     import Receive from "./Receive.svelte";
     import {navigationStore} from "../../stores/stores";
-    import {onMount} from "svelte";
     import Button from "../../components/Button.svelte";
     import type {AccountAction, NavigationState, SelectedAccountState} from "../../machinery/NavigationState";
     import {pushState} from "../../machinery/eventListener";
-    import {resolveBalance} from "../../machinery/nano-rpc-fetch-wrapper";
     import {loadWalletData} from "../../machinery/nano-ops";
     import {rawToNano} from "../../machinery/nanocurrency-web-wrapper";
     import LabelledLoader from "../../components/LabelledLoader.svelte";
@@ -22,7 +20,6 @@
     let selectedAccount: SelectedAccountState | undefined = undefined
     let account: NanoAccount | undefined = undefined;
     let separatorText: string | undefined = undefined
-    let balance: RAW | undefined
 
     let loading: boolean = false;
 
@@ -30,16 +27,7 @@
         state = value
         selectedAccount = state?.account
         account = selectedAccount?.selectedAccount;
-        separatorText = selectedAccount?.selectedAccount.alias
-    })
-
-    onMount(async () => {
-        try {
-            balance = await resolveBalance(selectedAccount.selectedAccount?.address)
-            separatorText = `${selectedAccount.selectedAccount?.alias} ${rawToNano(balance, 5).amount} Nano`
-        } catch (error) {
-            console.log('error loading balance')
-        }
+        separatorText = account ? `${account.alias} ${rawToNano(account.balance, 5).amount} Nano` : 'foo'
     })
 
     const setAccountAction = (a: AccountAction) => {
@@ -83,7 +71,7 @@
         <Seperator languageId="transactions" primaryText={selectedAccount?.selectedAccount.alias}/>
         <Transactions address={selectedAccount?.selectedAccount.address}/>
     {:else if selectedAccount?.view === 'send'}
-        <Send account={selectedAccount?.selectedAccount} balance={balance}/>
+        <Send account={selectedAccount?.selectedAccount} balance={selectedAccount?.selectedAccount.balance}/>
     {:else if selectedAccount?.view === 'receive'}
         <Receive account={selectedAccount?.selectedAccount} />
     {:else if selectedAccount?.view === 'settings'}

--- a/src/view/wallet/Account.svelte
+++ b/src/view/wallet/Account.svelte
@@ -27,7 +27,7 @@
         state = value
         selectedAccount = state?.account
         account = selectedAccount?.selectedAccount;
-        separatorText = account ? `${account.alias} ${rawToNano(account.balance, 5).amount} Nano` : 'foo'
+        separatorText = account ? `${account.alias} ${rawToNano(account.balance, 5).amount} Nano` : ''
     })
 
     const setAccountAction = (a: AccountAction) => {


### PR DESCRIPTION
There are certain RPC commands which can load for multiple accounts at once to save HTTP overhead. This loads balances for all accounts in the wallet. Also fixed a couple of quirks with the default state.