### PR TITLE
Improve wallet state

### DIFF
--- a/public/locales/en-US.properties
+++ b/public/locales/en-US.properties
@@ -70,6 +70,7 @@ unlocking-wallet = Unlocks..
 adding-account = Adds new account..
 loading-refresh = Loads transactions..
 sending-funds = Sending funds..
+loading-accounts = Loading accounts..
 
 # Onboard
 onboard-button-back = Back

--- a/src/machinery/NavigationState.ts
+++ b/src/machinery/NavigationState.ts
@@ -1,4 +1,3 @@
-import type { NanoAccount, NanoTransaction, NanoWallet } from './models';
 import type { WalletResult } from './wallet';
 
 export type MenuSelector =
@@ -9,17 +8,12 @@ export type MenuSelector =
   | 'unlock'
   | 'onboard';
 export type AccountAction =
+  | 'overview'
   | 'send'
   | 'transactions'
   | 'receive'
   | 'send_qr'
   | 'send_address';
-
-export interface SelectedAccountState {
-  selectedAccount: NanoAccount;
-  view: AccountAction | undefined;
-  selectedTransaction: NanoTransaction | undefined;
-}
 
 export type OnboardView = 'start' | 'disclaimer' | 'seed' | 'account' | 'pin';
 
@@ -31,14 +25,12 @@ export interface OnboardState {
 
 export interface NavigationState {
   menu: MenuSelector;
-  account: SelectedAccountState | undefined;
-  wallet: NanoWallet | undefined;
+  accountAction: AccountAction;
   onboardState: OnboardState | undefined;
 }
 
 export const START_STATE: NavigationState = {
   menu: 'unlock',
-  account: undefined,
-  wallet: undefined,
+  accountAction: undefined,
   onboardState: undefined,
 };

--- a/src/machinery/WalletState.ts
+++ b/src/machinery/WalletState.ts
@@ -1,0 +1,11 @@
+import type { NanoAddress, NanoWallet } from './models';
+import { walletStore } from '../stores/stores';
+
+export interface WalletState {
+  wallet: NanoWallet | undefined;
+  selectedAccount: NanoAddress | undefined;
+}
+
+export function setWalletState(walletState: WalletState) {
+  walletStore.set(walletState);
+}

--- a/src/machinery/eventListener.ts
+++ b/src/machinery/eventListener.ts
@@ -65,11 +65,6 @@ export function pushToast(state: ToastState): void {
   toastStore.set(state);
 }
 
-export function patchState(state: NavigationState): void {
-  stateHistory[index] = state;
-  navigationStore.set(state);
-}
-
 export function clearState(): void {
   stateHistory = [];
   index = 0;

--- a/src/machinery/eventListener.ts
+++ b/src/machinery/eventListener.ts
@@ -24,18 +24,15 @@ let stateHistory: NavigationState[] = [START_STATE];
 
 let index = 0;
 
-/** setTimeout hack needed to wire up navigation after DOM is loaded, there's probably a better way */
-navigationStore.subscribe(() => {
-  setTimeout(() => {
-    const elements: Element[] = Array.from(
-      document.getElementsByClassName('navigation')
-    );
-    document.removeEventListener('keydown', handleKeydown);
-    navigation = new Navigation(elements);
-    document.addEventListener('keydown', handleKeydown);
-    navigation.focus();
-  }, 100);
-});
+export const navigationReload = () => {
+  const elements: Element[] = Array.from(
+    document.getElementsByClassName('navigation')
+  );
+  document.removeEventListener('keydown', handleKeydown);
+  navigation = new Navigation(elements);
+  document.addEventListener('keydown', handleKeydown);
+  navigation.focus();
+};
 
 softwareKeysStore.subscribe((value: SoftwareKeysState) => {
   leftKey = value.leftKey?.onClick;

--- a/src/machinery/eventListener.ts
+++ b/src/machinery/eventListener.ts
@@ -5,6 +5,7 @@ import {
 } from '../stores/stores';
 import { Navigation } from './navigation';
 import type {
+  AccountAction,
   MenuSelector,
   NavigationState,
   OnboardState,
@@ -54,6 +55,10 @@ export function popState(): boolean {
 }
 export function pushMenu(menu: MenuSelector): void {
   pushState({ ...stateHistory[index], menu, onboardState: undefined });
+}
+
+export function pushAccountAction(action: AccountAction): void {
+  pushState({ ...stateHistory[index], accountAction: action });
 }
 
 export function pushToast(state: ToastState): void {

--- a/src/machinery/nano-ops.ts
+++ b/src/machinery/nano-ops.ts
@@ -70,15 +70,21 @@ async function resolvePendingForAccount(
       ? frontier
       : '0000000000000000000000000000000000000000000000000000000000000000';
   const work: string = await generateWork(frontierOrPublicKey, RECEIVE_WORK);
-  const block: SignedBlock = signReceiveBlock(
-    address,
-    privateKey,
-    work,
-    pendingBlock,
-    frontierOrInitial,
-    currentBalance
-  );
-  await processSimple(block);
+
+  const pendingBlocks: any[] = Object.keys(pendingBlock);
+  if (pendingBlocks.length > 0) {
+    const block: SignedBlock = signReceiveBlock(
+      address,
+      privateKey,
+      work,
+      pendingBlock,
+      frontierOrInitial,
+      currentBalance
+    );
+    await processSimple(block);
+  } else {
+    return;
+  }
 }
 
 export async function sendNano(

--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -1,17 +1,27 @@
-import { Writable, writable } from 'svelte/store';
 import type { NavigationState } from '../machinery/NavigationState';
 import type { SoftwareKeysState } from '../machinery/SoftwareKeysState';
-import { START_STATE } from '../machinery/NavigationState';
 import type { ToastState } from '../machinery/ToastState';
+import type { WalletState } from '../machinery/WalletState';
+import { Writable, writable } from 'svelte/store';
+import { START_STATE } from '../machinery/NavigationState';
 
+/** Handles navigation */
 export const navigationStore: Writable<NavigationState> = writable(START_STATE);
 
+/** Sets software / menu keys */
 export const softwareKeysStore: Writable<SoftwareKeysState> = writable({
   leftKey: undefined,
   middleKey: undefined,
   rightKey: undefined,
 });
 
+/** Controls global toast */
 export const toastStore: Writable<ToastState> = writable({
   languageId: null,
+});
+
+/** Handles updates of wallet */
+export const walletStore: Writable<WalletState> = writable({
+  wallet: undefined,
+  selectedAccount: undefined,
 });

--- a/src/view/Menu.svelte
+++ b/src/view/Menu.svelte
@@ -29,7 +29,7 @@
 <Content titleKey="menu">
     <List>
         <Primary primaryLanguageId="wallet" primaryText="wallet" on:click={() => setAppView('wallet')}/>
-        {#if selectedAccount}
+        {#if selectedAccount && state.accountAction}
             <WithSecondary primaryLanguageId="send" secondaryText={selectedAccount.alias} on:click={() => setWalletView('send')}/>
             <WithSecondary primaryLanguageId="transactions" secondaryText={selectedAccount.alias} on:click={() =>  setWalletView('transactions')}/>
             <WithSecondary primaryLanguageId="receive" secondaryText={selectedAccount.alias} on:click={() =>  setWalletView('receive')}/>

--- a/src/view/Menu.svelte
+++ b/src/view/Menu.svelte
@@ -1,33 +1,38 @@
 <script lang="ts">
-    import { navigationStore } from "../stores/stores";
+    import {navigationStore, walletStore} from "../stores/stores";
     import List from "../components/List.svelte";
     import Primary from "../components/list/Primary.svelte";
     import Content from "../components/Content.svelte";
     import WithSecondary from "../components/list/WithSecondary.svelte";
     import type {NavigationState, AccountAction, MenuSelector} from "../machinery/NavigationState";
+    import type {NanoAccount} from "../machinery/models";
     import {pushState} from "../machinery/eventListener";
 
     let state: NavigationState
+    let selectedAccount: NanoAccount | undefined
 
     navigationStore.subscribe(value => {
         state = value
     })
+    walletStore.subscribe(value => {
+        selectedAccount = value.wallet && value.selectedAccount ? value.wallet.accounts.filter(a => a.address === value.selectedAccount)[0] : undefined
+    })
 
     const setAppView = (menu: MenuSelector) => {
-        pushState({...state, menu: menu, account: undefined})
+        pushState({...state, menu: menu, accountAction: undefined })
     }
     const setWalletView = (a: AccountAction) => {
-        pushState({...state, menu: 'wallet', account: {...state.account, view: a}})
+        pushState({...state, menu: 'wallet', accountAction: a})
     }
 </script>
 
 <Content titleKey="menu">
     <List>
         <Primary primaryLanguageId="wallet" primaryText="wallet" on:click={() => setAppView('wallet')}/>
-        {#if state.account?.selectedAccount}
-            <WithSecondary primaryLanguageId="send" secondaryText={state.account?.selectedAccount.alias} on:click={() => setWalletView('send')}/>
-            <WithSecondary primaryLanguageId="transactions" secondaryText={state.account?.selectedAccount.alias} on:click={() =>  setWalletView('transactions')}/>
-            <WithSecondary primaryLanguageId="receive" secondaryText={state.account?.selectedAccount.alias} on:click={() =>  setWalletView('receive')}/>
+        {#if selectedAccount}
+            <WithSecondary primaryLanguageId="send" secondaryText={selectedAccount.alias} on:click={() => setWalletView('send')}/>
+            <WithSecondary primaryLanguageId="transactions" secondaryText={selectedAccount.alias} on:click={() =>  setWalletView('transactions')}/>
+            <WithSecondary primaryLanguageId="receive" secondaryText={selectedAccount.alias} on:click={() =>  setWalletView('receive')}/>
         {/if}
         <Primary primaryLanguageId="about" primaryText="about" on:click={() => setAppView('about')}/>
         <Primary primaryLanguageId="setup" primaryText="setup" on:click={() => setAppView('setup')}/>

--- a/src/view/Onboard.svelte
+++ b/src/view/Onboard.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
     import Content from "../components/Content.svelte";
     import Text from "../components/Text.svelte";
-    import {beforeUpdate, onMount} from "svelte";
+    import {afterUpdate, beforeUpdate, onMount} from "svelte";
     import {navigationStore, softwareKeysStore} from "../stores/stores";
-    import {pushOnboardState} from "../machinery/eventListener";
+    import {navigationReload, pushOnboardState} from "../machinery/eventListener";
     import type {NavigationState, OnboardState, OnboardView} from "../machinery/NavigationState";
     import Disclaimer from "./onboard/Disclaimer.svelte";
     import CreateSeed from "./onboard/CreateSeed.svelte";
     import AccountAlias from "./onboard/AccountAlias.svelte";
     import SetPIN from "./onboard/SetPIN.svelte";
     import type {WalletResult} from "../machinery/wallet";
+    import {setSoftwareKeys} from "../machinery/SoftwareKeysState";
 
     let onboardState: OnboardState | undefined = undefined
     let state: NavigationState | undefined = undefined
@@ -24,8 +25,8 @@
         walletResult = onboardState?.walletResult
         accountAlias = onboardState?.alias
     })
-    beforeUpdate(() => {
-        softwareKeysStore.set({
+    onMount(() => {
+        setSoftwareKeys({
             middleKey: {
                 languageId: 'onboard-start',
                 onClick: () => {
@@ -36,6 +37,7 @@
             rightKey: undefined,
         })
     })
+    afterUpdate(navigationReload)
 </script>
 
 

--- a/src/view/UnlockWallet.svelte
+++ b/src/view/UnlockWallet.svelte
@@ -18,11 +18,10 @@
     }
 
     const unlock = async () => {
-        clearSoftwareKeys();
+        clearSoftwareKeys()
         showLoader = true;
         const data: NanoWallet | undefined = await unlockWallet(inputPhrase)
         if(data) {
-            // clearState()
             pushState({menu: 'wallet', accountAction: undefined, onboardState: undefined})
             setWalletState({ wallet: data, selectedAccount: undefined })
         } else {

--- a/src/view/UnlockWallet.svelte
+++ b/src/view/UnlockWallet.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
     import Content from "../components/Content.svelte";
     import LabelledInput from "../components/LabelledInput.svelte";
-    import {clearState, pushMenu, pushState, pushToast} from "../machinery/eventListener";
+    import {clearState, navigationReload, pushMenu, pushState, pushToast} from "../machinery/eventListener";
     import type {NanoWallet} from "../machinery/models";
     import {unlockWallet} from "../machinery/secure-storage";
     import LabelledLoader from "../components/LabelledLoader.svelte";
-    import {onMount} from "svelte";
+    import {afterUpdate, onMount} from "svelte";
     import {clearSoftwareKeys, setSoftwareKeys} from "../machinery/SoftwareKeysState";
     import type {SoftwareKeysState} from "../machinery/SoftwareKeysState";
     import {setWalletState} from "../machinery/WalletState";
@@ -43,8 +43,11 @@
         rightKey: undefined
     }
 
-    onMount(() => setSoftwareKeys(softwareKeys))
 
+    afterUpdate(() => {
+        setSoftwareKeys(softwareKeys)
+        navigationReload();
+    })
 </script>
 
 <Content titleKey="unlock-wallet">

--- a/src/view/UnlockWallet.svelte
+++ b/src/view/UnlockWallet.svelte
@@ -6,9 +6,9 @@
     import {unlockWallet} from "../machinery/secure-storage";
     import LabelledLoader from "../components/LabelledLoader.svelte";
     import {onMount} from "svelte";
-    import {softwareKeysStore} from "../stores/stores";
     import {clearSoftwareKeys, setSoftwareKeys} from "../machinery/SoftwareKeysState";
     import type {SoftwareKeysState} from "../machinery/SoftwareKeysState";
+    import {setWalletState} from "../machinery/WalletState";
 
     let inputPhrase: string | undefined;
     let showLoader: boolean = false;
@@ -22,8 +22,9 @@
         showLoader = true;
         const data: NanoWallet | undefined = await unlockWallet(inputPhrase)
         if(data) {
-            clearState()
-            pushState({menu: 'wallet', wallet: data, account: undefined, onboardState: undefined})
+            // clearState()
+            pushState({menu: 'wallet', accountAction: undefined, onboardState: undefined})
+            setWalletState({ wallet: data, selectedAccount: undefined })
         } else {
             pushToast({ languageId: 'wrong-pass' })
             setSoftwareKeys(softwareKeys)

--- a/src/view/Wallet.svelte
+++ b/src/view/Wallet.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
-    import type {NanoAccount, NanoWallet, RAW} from "../machinery/models";
+    import type {NanoAccount, NanoWallet} from "../machinery/models";
     import List from "../components/List.svelte";
     import Account from "./wallet/Account.svelte";
-    import {navigationStore, softwareKeysStore, walletStore} from "../stores/stores";
+    import {navigationStore, walletStore} from "../stores/stores";
     import WithSecondary from "../components/list/WithSecondary.svelte";
     import Content from "../components/Content.svelte";
     import type {AccountAction, NavigationState} from "../machinery/NavigationState";
-    import {pushAccountAction, pushMenu, pushToast} from "../machinery/eventListener";
+    import {navigationReload, pushAccountAction, pushMenu, pushToast} from "../machinery/eventListener";
     import {addNanoAccount} from "../machinery/wallet";
     import LabelledLoader from "../components/LabelledLoader.svelte";
-    import {beforeUpdate, onMount} from "svelte";
+    import {afterUpdate, onMount} from "svelte";
     import {updateWalletAccounts} from "../machinery/nano-ops";
     import {setSoftwareKeys} from "../machinery/SoftwareKeysState";
     import {setWalletState} from "../machinery/WalletState";
@@ -72,6 +72,7 @@
         }
         loaderText = undefined
     })
+    afterUpdate(navigationReload)
 </script>
 
 {#if wallet}

--- a/src/view/onboard/Disclaimer.svelte
+++ b/src/view/onboard/Disclaimer.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
     import Text from "../../components/Text.svelte";
-    import {beforeUpdate} from "svelte";
+    import {onMount} from "svelte";
     import {softwareKeysStore} from "../../stores/stores";
     import {popState, pushOnboardState} from "../../machinery/eventListener";
     import Seperator from "../../components/Seperator.svelte";
 
-    beforeUpdate(() => {
+    onMount(() => {
         softwareKeysStore.set({
             middleKey: {
                 languageId: 'onboard-disclaimer-ok',

--- a/src/view/onboard/SetPIN.svelte
+++ b/src/view/onboard/SetPIN.svelte
@@ -7,7 +7,7 @@
     import {clearState, popState, pushMenu, pushToast} from "../../machinery/eventListener";
     import { softwareKeysStore } from "../../stores/stores";
     import LabelledLoader from "../../components/LabelledLoader.svelte";
-    import {beforeUpdate, onMount} from "svelte";
+    import {beforeUpdate} from "svelte";
 
     export let walletResult: WalletResult
     export let alias: string
@@ -27,11 +27,6 @@
             const storedWallet: NanoWallet | undefined = await createWallet(walletResult, inputPhrase, alias)
             if (storedWallet) {
                 clearState()
-                softwareKeysStore.set({
-                    middleKey: undefined,
-                    leftKey: undefined,
-                    rightKey: undefined,
-                })
                 pushMenu('unlock')
             } else {
                 pushToast({ languageId: 'onboard-store-wallet-failed' })

--- a/src/view/onboard/SetPIN.svelte
+++ b/src/view/onboard/SetPIN.svelte
@@ -7,7 +7,7 @@
     import {clearState, popState, pushMenu, pushToast} from "../../machinery/eventListener";
     import { softwareKeysStore } from "../../stores/stores";
     import LabelledLoader from "../../components/LabelledLoader.svelte";
-    import {beforeUpdate} from "svelte";
+    import {onMount} from "svelte";
 
     export let walletResult: WalletResult
     export let alias: string
@@ -35,7 +35,7 @@
         storing = false;
     }
 
-    beforeUpdate(() => {
+    onMount(() => {
         softwareKeysStore.set({
             middleKey: {
                 languageId: 'onboard-finish-button',

--- a/src/view/wallet/Account.svelte
+++ b/src/view/wallet/Account.svelte
@@ -6,13 +6,13 @@
     import Transactions from "./Transactions.svelte";
     import Receive from "./Receive.svelte";
     import type {AccountAction } from "../../machinery/NavigationState";
-    import {pushAccountAction} from "../../machinery/eventListener";
+    import {navigationReload, pushAccountAction} from "../../machinery/eventListener";
     import {loadWalletData} from "../../machinery/nano-ops";
     import {rawToNano} from "../../machinery/nanocurrency-web-wrapper";
     import LabelledLoader from "../../components/LabelledLoader.svelte";
     import Settings from "./Settings.svelte";
     import SendByAddress from "./Send.svelte";
-    import {onMount} from "svelte";
+    import {afterUpdate, onMount} from "svelte";
     import {setSoftwareKeys, SOFT_KEY_MENU} from "../../machinery/SoftwareKeysState";
 
     export let wallet: NanoWallet
@@ -49,6 +49,8 @@
         middleKey: undefined,
         rightKey: SOFT_KEY_MENU,
     }));
+
+    afterUpdate(navigationReload)
 
 </script>
 

--- a/src/view/wallet/Account.svelte
+++ b/src/view/wallet/Account.svelte
@@ -56,7 +56,7 @@
     <LabelledLoader languageId="loading-refresh"/>
 {:else}
     {#if action === 'overview'}
-        <Seperator languageId="actions" primaryText={accountTitle(selectedAccount)}/>
+        <Seperator primaryText={accountTitle(selectedAccount)}/>
         <List>
             <Primary primaryLanguageId="transactions" on:click={() => pushAccountAction('transactions') }/>
             <Primary primaryLanguageId="send" on:click={() => pushAccountAction('send') }/>

--- a/src/view/wallet/Send.svelte
+++ b/src/view/wallet/Send.svelte
@@ -7,7 +7,7 @@
     import {nanoToRaw, rawToNano} from "../../machinery/nanocurrency-web-wrapper";
     import CameraCapture from "../../components/CameraCapture.svelte";
     import LabelledLoader from "../../components/LabelledLoader.svelte";
-    import {popState} from "../../machinery/eventListener";
+    import {popState, pushAccountAction} from "../../machinery/eventListener";
     import type {AccountAction} from "../../machinery/NavigationState";
 
     export let sendType: AccountAction;
@@ -46,7 +46,7 @@
             sending = true;
             try {
                 await sendNano(account, toAddress, nanoToRaw({amount: sendValue.toString()}), balance)
-                popState();
+                pushAccountAction('overview')
             } catch (e) {
                 console.log(e)
             }

--- a/src/view/wallet/Settings.svelte
+++ b/src/view/wallet/Settings.svelte
@@ -1,21 +1,28 @@
 <script lang="ts">
-    import type {NanoAccount} from "../../machinery/models";
+    import type {NanoAccount, NanoWallet} from "../../machinery/models";
     import Seperator from "../../components/Seperator.svelte";
     import LabelledInput from "../../components/LabelledInput.svelte";
     import Button from "../../components/Button.svelte";
+    import {setWallet} from "../../machinery/secure-storage";
+    import {setWalletState} from "../../machinery/WalletState";
+    import {pushAccountAction} from "../../machinery/eventListener";
 
-    export let account: NanoAccount;
-    export let storeFunction: () => void
+    export let wallet: NanoWallet;
+    export let selectedAccount: NanoAccount;
 
-    let aliasValue: string = account?.alias
+    let aliasValue: string = selectedAccount?.alias
 
     const setAlias = (event) => {
         aliasValue = event.target.value;
     }
 
     const save = async () => {
-        account.alias = aliasValue
-        storeFunction()
+        selectedAccount.alias = aliasValue
+        const updated: NanoWallet | undefined = await setWallet(wallet)
+        if (updated) {
+            setWalletState({wallet: updated, selectedAccount: selectedAccount?.address})
+            pushAccountAction('overview')
+        } // TODO: Toast
     }
 
 </script>


### PR DESCRIPTION
This moves away from combining wallet + navigation state to two independent stores. This makes it easier to keep track of updated wallet and avoids messing with patching navigation state.