### PR TITLE
Update in account updates wallet state

### DIFF
--- a/public/locales/en-US.properties
+++ b/public/locales/en-US.properties
@@ -39,6 +39,7 @@ send-button = Send
 send-max-button = Max
 send-scan-qr = Scan QR code
 qr-capture-image = Capture QR code
+unable-to-send = Unable to send, please update
 
 
 #QRCode Send

--- a/src/machinery/nano-ops.ts
+++ b/src/machinery/nano-ops.ts
@@ -96,7 +96,7 @@ export async function sendNano(
   toAddress: NanoAddress,
   amount: RAW,
   balance: RAW
-): Promise<void> {
+): Promise<NanoAccount | undefined> {
   try {
     const frontiers:
       | Map<string, Frontier>
@@ -113,6 +113,7 @@ export async function sendNano(
       workHash
     );
     await processSimple(signed);
+    return updateWalletAccount(account);
   } catch (error) {
     console.log(error);
   }

--- a/src/machinery/nano-ops.ts
+++ b/src/machinery/nano-ops.ts
@@ -19,6 +19,7 @@ import {
   loadBlocks,
   loadFrontiers,
   processSimple,
+  resolveBalance,
   resolveBalances,
 } from './nano-rpc-fetch-wrapper';
 import { signReceiveBlock, signSendBlock } from './nanocurrency-web-wrapper';
@@ -28,7 +29,9 @@ import { signReceiveBlock, signSendBlock } from './nanocurrency-web-wrapper';
 const SEND_WORK = 'fffffff800000000';
 const RECEIVE_WORK = 'fffffe0000000000';
 
-export async function loadWalletData(account: NanoAccount): Promise<void> {
+export async function loadWalletData(
+  account: NanoAccount
+): Promise<NanoAccount> {
   const pending: {
     [key: string]: PendingBlock;
   } = await getPendingBlocksSimple([account.address]);
@@ -52,6 +55,7 @@ export async function loadWalletData(account: NanoAccount): Promise<void> {
     frontier,
     currentBalance
   );
+  return await updateWalletAccount(account);
 }
 
 async function resolvePendingForAccount(
@@ -128,4 +132,14 @@ export async function updateWalletAccounts(
     };
   });
   return wallet;
+}
+
+export async function updateWalletAccount(
+  account: NanoAccount
+): Promise<NanoAccount> {
+  const balance = await resolveBalance(account.address);
+  return {
+    ...account,
+    balance: balance,
+  };
 }

--- a/src/view/wallet/Account.svelte
+++ b/src/view/wallet/Account.svelte
@@ -78,7 +78,7 @@
         <Transactions address={selectedAccount.address}/>
     {:else if action.startsWith('send')}
         {#if action === 'send_qr' || action === 'send_address'}
-            <SendByAddress account={selectedAccount} balance={selectedAccount.balance} sendType={action} setType={(action) => pushAccountAction(action)} />
+            <SendByAddress wallet={wallet} account={selectedAccount} balance={selectedAccount.balance} sendType={action} setType={(action) => pushAccountAction(action)} />
         {:else}
             <List>
                 <Primary primaryText="Send by QR code" on:click={() => pushAccountAction('send_qr')}/>

--- a/src/view/wallet/Account.svelte
+++ b/src/view/wallet/Account.svelte
@@ -5,7 +5,7 @@
     import Primary from "../../components/list/Primary.svelte";
     import Transactions from "./Transactions.svelte";
     import Receive from "./Receive.svelte";
-    import type {AccountAction } from "../../machinery/NavigationState";
+    import type {AccountAction} from "../../machinery/NavigationState";
     import {navigationReload, pushAccountAction} from "../../machinery/eventListener";
     import {loadWalletData} from "../../machinery/nano-ops";
     import {rawToNano} from "../../machinery/nanocurrency-web-wrapper";
@@ -14,6 +14,7 @@
     import SendByAddress from "./Send.svelte";
     import {afterUpdate, onMount} from "svelte";
     import {setSoftwareKeys, SOFT_KEY_MENU} from "../../machinery/SoftwareKeysState";
+    import {walletStore} from "../../stores/stores";
 
     export let wallet: NanoWallet
     export let selectedAccount: NanoAccount
@@ -34,7 +35,14 @@
     const triggerRefresh = async () => {
         loading = true;
         try {
-            await loadWalletData(selectedAccount)
+            const updatedAccount = await loadWalletData(selectedAccount)
+            wallet.accounts = wallet.accounts.map(account => {
+                return account.address === updatedAccount.address ? updatedAccount : account
+            })
+            walletStore.set({
+                wallet: wallet,
+                selectedAccount: updatedAccount.address
+            })
         } catch (e) {
             console.log(e)
         }


### PR DESCRIPTION
State was never reflected properly on the "update"-menu button. Blocks were only resolved (if any pending) and send off to the node. This leads to two RPC calls on "updated", first resolving blocks, and then fetching the current state for the account.
 
Fixes #65 