### PR TITLE
Configure representative

### DIFF
--- a/public/css/kaiui.css
+++ b/public/css/kaiui.css
@@ -92,10 +92,10 @@ h1, h2, h3, h4, h5, ul, p {
 .kui-text {
     font-size: 17px;
     font-weight: 400;
+    padding: 5px;
 }
 
 .kui-body {
-    padding: 0 10px 10px 10px;
 }
 
 .kui-text-break{

--- a/public/locales/en-US.properties
+++ b/public/locales/en-US.properties
@@ -1,6 +1,7 @@
 # General
 continue = Continue
 accept = Accept
+change = Change
 
 #Navigation
 rightNavButton = Menu
@@ -25,6 +26,8 @@ unnamed-account = Unnamed
 settings = Settings
 account-settings = Account settings
 account-alias = Alias (min. 3 characters)
+set-representative = Set representative
+
 
 #Receive
 add-account = Add account

--- a/public/locales/en-US.properties
+++ b/public/locales/en-US.properties
@@ -3,6 +3,8 @@ continue = Continue
 accept = Accept
 change = Change
 set = Set
+representative = Representative
+invalid-address = Invalid Nano address
 
 #Navigation
 rightNavButton = Menu
@@ -27,9 +29,10 @@ unnamed-account = Unnamed
 settings = Settings
 account-settings = Account settings
 account-alias = Alias (min. 3 characters)
+representative-text = Delegate your stake to a representative
 set-representative = Set representative
 no-representative-set = No representative set
-unable-to-load-representative = Unable to load representative address
+unable-to-load-representative = Unable to load representative for account
 
 #Receive
 add-account = Add account
@@ -99,6 +102,7 @@ loading-accounts = Loading accounts..
 loading-transactions = Loading transactions..
 decoding-qr = Decoding QR..
 loading-settings = Loading settings..
+loading-account = Loading account..
 
 # Onboard
 new-wallet = New wallet
@@ -109,8 +113,9 @@ onboard-seed-title = The mnemonic & seed
 onboard-disclaimer-text = The mnemonic or seed is the only way to restore your wallet. Please store this somewhere safe as a backup. The seed will also encrypted on the device.
 onboard-disclaimer-ok = Ok
 onboard-set-alias = Account alias
-onboard-set-alias-text = Set an alias for your first account. Alias can be changed at a later time.
+onboard-set-alias-text = Set an alias for this account. Alias can be changed at any time.
 onboard-set-alias-button = Set alias
+onboard-alias-rule = Alias must be at least 3 characters
 onboard-finish = Set alias
 onboard-finish-button = Finish
 onboard-set-wallet-pin-text = Set a wallet PIN to protect your wallet on the device.

--- a/public/locales/en-US.properties
+++ b/public/locales/en-US.properties
@@ -29,6 +29,7 @@ account-settings = Account settings
 account-alias = Alias (min. 3 characters)
 set-representative = Set representative
 no-representative-set = No representative set
+unable-to-load-representative = Unable to load representative address
 
 #Receive
 add-account = Add account
@@ -97,6 +98,7 @@ sending-funds = Sending funds..
 loading-accounts = Loading accounts..
 loading-transactions = Loading transactions..
 decoding-qr = Decoding QR..
+loading-settings = Loading settings..
 
 # Onboard
 new-wallet = New wallet

--- a/public/locales/en-US.properties
+++ b/public/locales/en-US.properties
@@ -2,6 +2,7 @@
 continue = Continue
 accept = Accept
 change = Change
+set = Set
 
 #Navigation
 rightNavButton = Menu
@@ -27,7 +28,7 @@ settings = Settings
 account-settings = Account settings
 account-alias = Alias (min. 3 characters)
 set-representative = Set representative
-
+no-representative-set = No representative set
 
 #Receive
 add-account = Add account

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -28,10 +28,7 @@
 
 	const unsubscribeLoader = loaderStore.subscribe((value) => loader = value)
 	const unsubscribeNavigation = navigationStore.subscribe<NavigationState>(value => state = value);
-	const unsubscribeWalletStore = walletStore.subscribe<WalletState>(value => {
-		walletState = value
-		console.log(walletState)
-	})
+	const unsubscribeWalletStore = walletStore.subscribe<WalletState>(value => walletState = value);
 
 	onDestroy(() => {
 		unsubscribeLoader()
@@ -60,7 +57,7 @@
 				<UnlockWallet />
 			{:else if state.menu === 'accounts' && walletState?.wallet}
 				<AccountList wallet={walletState.wallet} />
-			{:else if state.menu === 'account' && walletState?.wallet && walletState?.selectedAccount}
+			{:else if state.menu === 'account' && walletState?.wallet && walletState?.account}
 				<Wallet walletState={walletState} accountAction={state.accountAction} fullscreen={fullscreen} />
 			{:else if state.menu === 'onboard'}
 				<Onboard />

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -65,7 +65,7 @@
 			{:else if state.menu === 'onboard'}
 				<Onboard />
 			{:else if state.menu === 'setup' && state.setupAction}
-				<Setup setupAction={state.setupAction} />
+				<Setup setupAction={state.setupAction} wallet={walletState} />
 			{:else if state.menu === 'menu'}
 				<Menu wallet={walletState} accountAction={state.accountAction}/>
 			{:else if state.menu === 'about'}

--- a/src/components/input/TextArea.svelte
+++ b/src/components/input/TextArea.svelte
@@ -12,5 +12,5 @@
     }
 </style>
 <LabelInput languageId={languageId} text={text}>
-    <textarea id={languageId} class="kui-input kui-text navigation" data-l10n-id={placeholderLanguage} on:input value={value} rows="4"></textarea>
+    <textarea id={languageId} class="kui-input kui-text navigation" data-l10n-id={placeholderLanguage} on:input rows="4">{value}</textarea>
 </LabelInput>

--- a/src/components/input/TextInput.svelte
+++ b/src/components/input/TextInput.svelte
@@ -3,8 +3,8 @@
     export let languageId: string | undefined
     export let text: string | undefined
     export let placeholderLanguage: string | undefined
-    export let value: string = '';
+    export let value: string | undefined = ''
 </script>
-<LabelInput languageId={languageId} text={text}>
+<LabelInput languageId={languageId} text={text} >
     <input id={languageId} type="text" class="kui-input kui-text navigation" data-l10n-id={placeholderLanguage} on:input value={value}>
 </LabelInput>

--- a/src/components/list/WithSecondary.svelte
+++ b/src/components/list/WithSecondary.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
+    import ListItem from "./ListItem.svelte";
     export let primaryLanguageId: string | undefined;
     export let primaryText: string | undefined;
     export let secondaryLanguageId : string | undefined;
     export let secondaryText: string | undefined;
 </script>
-<li tabindex="1" class="navigation" on:click>
-    <div class="kui-list-cont">
-        <p class="kui-pri" data-l10n-id="{primaryLanguageId}">{primaryText}</p>
-        <p class="kui-sec" data-l10n-id="{secondaryLanguageId}">{secondaryText}</p>
-    </div>
-</li>
+<ListItem on:click>
+    <p class="kui-pri" data-l10n-id="{primaryLanguageId}">{primaryText}</p>
+    <p class="kui-sec" data-l10n-id="{secondaryLanguageId}">{secondaryText}</p>
+</ListItem>

--- a/src/machinery/NavigationState.ts
+++ b/src/machinery/NavigationState.ts
@@ -27,7 +27,7 @@ export type OnboardView =
   | 'disclaimer-import'
   | 'input-import';
 
-export type SetupAction = 'menu' | 'export-seed' | 'representative';
+export type SetupAction = 'menu' | 'export-seed';
 
 export interface OnboardState {
   view: OnboardView;

--- a/src/machinery/NavigationState.ts
+++ b/src/machinery/NavigationState.ts
@@ -15,7 +15,8 @@ export type AccountAction =
   | 'transactions'
   | 'receive'
   | 'send_qr'
-  | 'send_address';
+  | 'send_address'
+  | 'settings';
 
 export type OnboardView =
   | 'start'
@@ -26,7 +27,7 @@ export type OnboardView =
   | 'disclaimer-import'
   | 'input-import';
 
-export type SetupAction = 'menu' | 'export-seed';
+export type SetupAction = 'menu' | 'export-seed' | 'representative';
 
 export interface OnboardState {
   view: OnboardView;

--- a/src/machinery/WalletState.ts
+++ b/src/machinery/WalletState.ts
@@ -1,10 +1,16 @@
-import type { NanoAddress, NanoTransaction, NanoWallet } from './models';
+import type {
+  NanoAccount,
+  NanoAddress,
+  NanoTransaction,
+  NanoWallet,
+} from './models';
 import { walletStore } from '../stores/stores';
 
 export interface WalletState {
   wallet: NanoWallet | undefined;
   selectedAccount?: NanoAddress;
   transactions?: NanoTransaction[];
+  account?: NanoAccount;
 }
 
 export function setWalletState(walletState: WalletState) {

--- a/src/machinery/WalletState.ts
+++ b/src/machinery/WalletState.ts
@@ -8,7 +8,6 @@ import { walletStore } from '../stores/stores';
 
 export interface WalletState {
   wallet: NanoWallet | undefined;
-  selectedAccount?: NanoAddress;
   transactions?: NanoTransaction[];
   account?: NanoAccount;
 }

--- a/src/machinery/WalletState.ts
+++ b/src/machinery/WalletState.ts
@@ -1,9 +1,4 @@
-import type {
-  NanoAccount,
-  NanoAddress,
-  NanoTransaction,
-  NanoWallet,
-} from './models';
+import type { NanoAccount, NanoTransaction, NanoWallet } from './models';
 import { walletStore } from '../stores/stores';
 
 export interface WalletState {

--- a/src/machinery/eventListener.ts
+++ b/src/machinery/eventListener.ts
@@ -135,10 +135,10 @@ export async function handleKeydown(e) {
       }
       break;
     case 'Enter':
-      if (middleKey) {
-        await middleKey();
-      } else if (navigation.selection()) {
+      if (navigation.isClickableElement()) {
         navigation.selection().click();
+      } else if (middleKey) {
+        await middleKey();
       }
       e.preventDefault();
       break;

--- a/src/machinery/models.ts
+++ b/src/machinery/models.ts
@@ -10,6 +10,7 @@ export interface NanoAccount {
   publicKey: PrivateKey;
   privateKey: PrivateKey;
   balance: RAW | undefined;
+  representative?: NanoAddress;
 }
 
 export interface NanoWallet {

--- a/src/machinery/nano-ops.ts
+++ b/src/machinery/nano-ops.ts
@@ -16,7 +16,7 @@ import type {
 import {
   generateWork,
   getPendingBlocksSimple,
-  getRepresentatives,
+  getRepresentative,
   loadBlocks,
   loadFrontiers,
   processSimple,
@@ -127,7 +127,7 @@ export async function updateWalletAccounts(
   const balances: {
     [address: string]: AccountBalanceResponse;
   } = await resolveBalances(addresses);
-  const representatives = await getRepresentatives(addresses);
+  const representatives = await getRepresentative(addresses);
   wallet.accounts = wallet.accounts.map((a, index) => {
     return {
       ...a,

--- a/src/machinery/nano-ops.ts
+++ b/src/machinery/nano-ops.ts
@@ -16,6 +16,7 @@ import type {
 import {
   generateWork,
   getPendingBlocksSimple,
+  getRepresentatives,
   loadBlocks,
   loadFrontiers,
   processSimple,
@@ -126,10 +127,12 @@ export async function updateWalletAccounts(
   const balances: {
     [address: string]: AccountBalanceResponse;
   } = await resolveBalances(addresses);
-  wallet.accounts = wallet.accounts.map((a) => {
+  const representatives = await getRepresentatives(addresses);
+  wallet.accounts = wallet.accounts.map((a, index) => {
     return {
       ...a,
       balance: { raw: balances[a.address].balance.toString() },
+      representative: representatives[index],
     };
   });
   return wallet;

--- a/src/machinery/nano-ops.ts
+++ b/src/machinery/nano-ops.ts
@@ -154,7 +154,6 @@ export async function updateNanoAccount(
 ): Promise<NanoAccount> {
   const balance = await resolveBalance(account.address);
   const representative = await getRepresentative(account.address);
-
   return {
     ...account,
     representative: representative,

--- a/src/machinery/nano-rpc-fetch-wrapper.ts
+++ b/src/machinery/nano-rpc-fetch-wrapper.ts
@@ -5,7 +5,6 @@ import {
   AccountHistoryRequestActionEnum,
   AccountHistoryResponse,
   AccountRepresentativeRequestActionEnum,
-  AccountRepresentativeResponse,
   AccountsBalancesRequestActionEnum,
   AccountsBalancesResponse,
   AccountsFrontiersRequestActionEnum,

--- a/src/machinery/nano-rpc-fetch-wrapper.ts
+++ b/src/machinery/nano-rpc-fetch-wrapper.ts
@@ -4,6 +4,8 @@ import {
   AccountBalanceResponse,
   AccountHistoryRequestActionEnum,
   AccountHistoryResponse,
+  AccountRepresentativeRequestActionEnum,
+  AccountRepresentativeResponse,
   AccountsBalancesRequestActionEnum,
   AccountsBalancesResponse,
   AccountsFrontiersRequestActionEnum,
@@ -49,6 +51,22 @@ export async function resolveBalances(
     },
   });
   return response.balances;
+}
+
+export async function getRepresentatives(
+  addresses: NanoAddress[]
+): Promise<NanoAddress[]> {
+  const requests = addresses.map((a) => {
+    return nanoApi.accountRepresentative({
+      accountRepresentativeRequest: {
+        action: AccountRepresentativeRequestActionEnum.AccountRepresentative,
+        account: a,
+      },
+    });
+  });
+  return await Promise.all(requests).then((res) =>
+    res.map((a) => a.representative)
+  );
 }
 
 export async function processSimple(block: any): Promise<ProcessResponse> {

--- a/src/machinery/nano-rpc-fetch-wrapper.ts
+++ b/src/machinery/nano-rpc-fetch-wrapper.ts
@@ -53,20 +53,16 @@ export async function resolveBalances(
   return response.balances;
 }
 
-export async function getRepresentatives(
-  addresses: NanoAddress[]
-): Promise<NanoAddress[]> {
-  const requests = addresses.map((a) => {
-    return nanoApi.accountRepresentative({
-      accountRepresentativeRequest: {
-        action: AccountRepresentativeRequestActionEnum.AccountRepresentative,
-        account: a,
-      },
-    });
+export async function getRepresentative(
+  address: NanoAddress
+): Promise<NanoAddress> {
+  const response = await nanoApi.accountRepresentative({
+    accountRepresentativeRequest: {
+      action: AccountRepresentativeRequestActionEnum.AccountRepresentative,
+      account: address,
+    },
   });
-  return await Promise.all(requests).then((res) =>
-    res.map((a) => a.representative)
-  );
+  return response.representative;
 }
 
 export async function processSimple(block: any): Promise<ProcessResponse> {

--- a/src/machinery/nanocurrency-web-wrapper.ts
+++ b/src/machinery/nanocurrency-web-wrapper.ts
@@ -4,6 +4,7 @@ import type {
   SendBlock,
   SignedBlock,
   ReceiveBlock,
+  RepresentativeBlock,
 } from 'nanocurrency-web/dist/lib/block-signer';
 
 function round(number: number, places: number): number {
@@ -81,4 +82,23 @@ export function signSendBlock(
   };
 
   return block.send(data, privateKey);
+}
+
+export function signRepresentativeBlock(
+  privateKey: PrivateKey,
+  walletBalance: RAW,
+  address: NanoAddress,
+  representativeAddress: NanoAddress,
+  frontier: string,
+  workHash: string
+): SignedBlock {
+  const data: RepresentativeBlock = {
+    walletBalanceRaw: walletBalance.raw,
+    address: address,
+    representativeAddress: representativeAddress,
+    frontier: frontier,
+    work: workHash,
+  };
+
+  return block.representative(data, privateKey);
 }

--- a/src/machinery/nanocurrency-web-wrapper.ts
+++ b/src/machinery/nanocurrency-web-wrapper.ts
@@ -7,6 +7,9 @@ import type {
   RepresentativeBlock,
 } from 'nanocurrency-web/dist/lib/block-signer';
 
+const DEFAULT_REP: NanoAddress =
+  'nano_3n7ky76t4g57o9skjawm8pprooz1bminkbeegsyt694xn6d31c6s744fjzzz';
+
 function round(number: number, places: number): number {
   return +(Math.round(Number(number + 'e+' + places)) + 'e-' + places);
 }
@@ -41,7 +44,8 @@ export function signReceiveBlock(
   workHash: string,
   pendingBlock: any,
   frontier: Frontier,
-  walletBalance: RAW
+  walletBalance: RAW,
+  representative: NanoAddress | undefined
 ): SignedBlock {
   const blockHash = Object.keys(pendingBlock)[0];
 
@@ -52,8 +56,7 @@ export function signReceiveBlock(
     toAddress: address,
     transactionHash: blockHash,
     frontier: frontier,
-    representativeAddress:
-      'nano_1hzoje373eapce4ses7xsx539suww5555hi9q8i8j7hpbayzxq4c4nn91hr8', // TODO
+    representativeAddress: representative || DEFAULT_REP,
     amountRaw: amount,
     work: workHash,
   };
@@ -68,14 +71,14 @@ export function signSendBlock(
   toAddress: NanoAddress,
   frontier: string,
   amount: RAW,
-  workHash: string
+  workHash: string,
+  representative: NanoAddress
 ): SignedBlock {
   const data: SendBlock = {
     walletBalanceRaw: walletBalance.raw,
     fromAddress: fromAddress,
     toAddress: toAddress,
-    representativeAddress:
-      'nano_1hzoje373eapce4ses7xsx539suww5555hi9q8i8j7hpbayzxq4c4nn91hr8', // TODO
+    representativeAddress: representative,
     frontier: frontier,
     amountRaw: amount.raw,
     work: workHash,

--- a/src/machinery/navigation.ts
+++ b/src/machinery/navigation.ts
@@ -73,4 +73,13 @@ export class Navigation {
       ? this.inputSelection().selectionStart !== 0
       : false;
   }
+
+  isClickableElement(): boolean {
+    return (
+      this.selectedElement &&
+      (this.selectedElement instanceof HTMLButtonElement ||
+        this.selectedElement instanceof HTMLLIElement) &&
+      this.selectedElement.click !== undefined
+    );
+  }
 }

--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -15,6 +15,5 @@ export const toastStore: Writable<ToastState> = writable({
 /** Handles updates of wallet */
 export const walletStore: Writable<WalletState> = writable({
   wallet: undefined,
-  selectedAccount: undefined,
   transactions: undefined,
 });

--- a/src/view/AccountList.svelte
+++ b/src/view/AccountList.svelte
@@ -19,7 +19,6 @@
                 const updatedAccount = await updateNanoAccount(account)
                 setWalletState({
                     wallet: wallet,
-                    selectedAccount: account.address,
                     account: updatedAccount
                 })
                 pushAccountAction('menu')

--- a/src/view/AccountList.svelte
+++ b/src/view/AccountList.svelte
@@ -9,14 +9,24 @@
     import {load} from "../machinery/loader-store";
     import {addNanoAccount} from "../machinery/wallet";
     import {truncateNanoAddress} from "../machinery/nanocurrency-web-wrapper";
+    import {updateNanoAccount} from "../machinery/nano-ops";
 
     export let wallet: NanoWallet
-    const selectAccount = (account: NanoAccount) => {
-        setWalletState({
-            wallet: wallet,
-            selectedAccount: account.address
+    const selectAccount = async (account: NanoAccount) => {
+        await load({
+            languageId: 'loading-account',
+            load: async () => {
+                const updatedAccount = await updateNanoAccount(account)
+                setWalletState({
+                    wallet: wallet,
+                    selectedAccount: account.address,
+                    account: updatedAccount
+                })
+                pushAccountAction('menu')
+            }
         })
-        pushAccountAction('menu')
+
+
     }
 
     const addAccount = async () => {

--- a/src/view/Menu.svelte
+++ b/src/view/Menu.svelte
@@ -12,7 +12,6 @@
 
     export let wallet: WalletState | undefined
     export let accountAction: AccountAction | undefined = undefined
-    let selectedAccount: NanoAccount | undefined = wallet && wallet.selectedAccount ? wallet.wallet.accounts.filter(w => w.address === wallet.selectedAccount)[0] : undefined;
 
     afterUpdate(() => navigationReload(
         {
@@ -27,10 +26,10 @@
 <Content titleKey="menu">
     <List>
         <Primary primaryLanguageId="wallet" primaryText="wallet" on:click={() => pushMenu('accounts')}/>
-        {#if selectedAccount && accountAction === 'menu'}
-            <WithSecondary primaryLanguageId="send" secondaryText={selectedAccount.alias} on:click={() => pushAccountAction('send')}/>
-            <WithSecondary primaryLanguageId="transactions" secondaryText={selectedAccount.alias} on:click={() =>  pushAccountAction('transactions')}/>
-            <WithSecondary primaryLanguageId="receive" secondaryText={selectedAccount.alias} on:click={() =>  pushAccountAction('receive')}/>
+        {#if wallet.account && accountAction === 'menu'}
+            <WithSecondary primaryLanguageId="send" secondaryText={wallet.account.alias} on:click={() => pushAccountAction('send')}/>
+            <WithSecondary primaryLanguageId="transactions" secondaryText={wallet.account.alias} on:click={() =>  pushAccountAction('transactions')}/>
+            <WithSecondary primaryLanguageId="receive" secondaryText={wallet.account.alias} on:click={() =>  pushAccountAction('receive')}/>
         {/if}
         <Primary primaryLanguageId="about" primaryText="about" on:click={() => pushMenu('about')}/>
         <Primary primaryLanguageId="setup" primaryText="setup" on:click={() => pushSetupAction('menu')}/>

--- a/src/view/Menu.svelte
+++ b/src/view/Menu.svelte
@@ -26,7 +26,7 @@
 <Content titleKey="menu">
     <List>
         <Primary primaryLanguageId="wallet" primaryText="wallet" on:click={() => pushMenu('accounts')}/>
-        {#if wallet.account && accountAction === 'menu'}
+        {#if wallet.account}
             <WithSecondary primaryLanguageId="send" secondaryText={wallet.account.alias} on:click={() => pushAccountAction('send')}/>
             <WithSecondary primaryLanguageId="transactions" secondaryText={wallet.account.alias} on:click={() =>  pushAccountAction('transactions')}/>
             <WithSecondary primaryLanguageId="receive" secondaryText={wallet.account.alias} on:click={() =>  pushAccountAction('receive')}/>

--- a/src/view/UnlockWallet.svelte
+++ b/src/view/UnlockWallet.svelte
@@ -36,10 +36,9 @@
             languageId: 'unlocking-wallet',
             load: async () => {
                 const data: NanoWallet | undefined = await unlockWallet(inputPhrase)
-                const updatedNanoWallet: NanoWallet = await tryGetTransactions(data)
-                if (updatedNanoWallet) {
+                if (data) {
                     pushState({menu: 'accounts', accountAction: undefined, onboardState: undefined})
-                    setWalletState({wallet: updatedNanoWallet, selectedAccount: undefined})
+                    setWalletState({wallet: data, account: undefined})
                 } else {
                     pushToast({languageId: 'wrong-pass'})
                 }

--- a/src/view/Wallet.svelte
+++ b/src/view/Wallet.svelte
@@ -1,23 +1,18 @@
 <script lang="ts">
-    import type {NanoAccount, NanoTransaction} from "../machinery/models";
+    import type {NanoTransaction} from "../machinery/models";
     import Account from "./wallet/Account.svelte";
     import Content from "../components/Content.svelte";
     import type {AccountAction} from "../machinery/NavigationState";
     import type {WalletState} from "../machinery/WalletState";
 
-    const getSelectedAccount = (state: WalletState): NanoAccount | undefined => {
-        return state.wallet && state.selectedAccount ? state.wallet.accounts.filter(a => a.address === state.selectedAccount)[0] : undefined
-    }
-
     export let walletState: WalletState
     export let accountAction: AccountAction | undefined
     export let fullscreen: boolean = false;
-    $: selectedAccount = getSelectedAccount(walletState)
 
     let transactions: NanoTransaction[] | undefined = walletState?.transactions;
 </script>
 
 <Content titleKey="account" fullscreen={fullscreen}>
-    <Account wallet={walletState.wallet} selectedAccount={selectedAccount} action={accountAction} transactions={transactions}/>
+    <Account wallet={walletState.wallet} selectedAccount={walletState.account} action={accountAction} transactions={transactions}/>
 </Content>
 

--- a/src/view/wallet/Account.svelte
+++ b/src/view/wallet/Account.svelte
@@ -11,11 +11,11 @@
     import {rawToNano} from "../../machinery/nanocurrency-web-wrapper";
     import Settings from "./Settings.svelte";
     import SendByAddress from "./Send.svelte";
-    import {afterUpdate, beforeUpdate} from "svelte";
+    import {afterUpdate} from "svelte";
     import {SOFT_KEY_MENU} from "../../machinery/SoftwareKeysState";
     import {walletStore} from "../../stores/stores";
     import {load} from "../../machinery/loader-store";
-    import {resolveHistory} from "../../machinery/nano-rpc-fetch-wrapper";
+    import {getRepresentative, resolveHistory} from "../../machinery/nano-rpc-fetch-wrapper";
     import {setWalletState} from "../../machinery/WalletState";
     import SendSelector from "./SendSelector.svelte";
 
@@ -45,6 +45,19 @@
                     transactions: resolvedTransactions
                 })
                 pushAccountAction('transactions')
+            }
+        })
+    }
+
+    const showSettings = async () => {
+        await load({
+            languageId: 'loading-settings',
+            load: async () => {
+                selectedAccount.representative = await getRepresentative(selectedAccount.address)
+                pushAccountAction('settings')
+            },
+            onError: () => {
+              pushToast({ languageId: 'unable-to-load-representative' })
             }
         })
     }
@@ -90,7 +103,7 @@
         <Primary primaryLanguageId="transactions" on:click={showTransactions}/>
         <Primary primaryLanguageId="send" on:click={() => pushAccountAction('send') }/>
         <Primary primaryLanguageId="receive" on:click={() => pushAccountAction('receive') }/>
-        <Primary primaryLanguageId="settings" on:click={() => pushAccountAction('settings') }/>
+        <Primary primaryLanguageId="settings" on:click={() => showSettings() }/>
     </List>
 {:else if action === 'transactions'}
     <Seperator languageId="transactions" primaryText={selectedAccount.alias}/>

--- a/src/view/wallet/Account.svelte
+++ b/src/view/wallet/Account.svelte
@@ -41,7 +41,7 @@
                 const resolvedTransactions = await resolveHistory(selectedAccount.address)
                 setWalletState({
                     wallet: wallet,
-                    selectedAccount: selectedAccount.address,
+                    account: selectedAccount,
                     transactions: resolvedTransactions
                 })
                 pushAccountAction('transactions')
@@ -76,7 +76,7 @@
                 })
                 walletStore.set({
                     wallet: wallet,
-                    selectedAccount: updatedAccount.address,
+                    account: updatedAccount,
                     transactions: resolvedTransactions,
                 })
             }

--- a/src/view/wallet/Account.svelte
+++ b/src/view/wallet/Account.svelte
@@ -15,7 +15,7 @@
     import {SOFT_KEY_MENU} from "../../machinery/SoftwareKeysState";
     import {walletStore} from "../../stores/stores";
     import {load} from "../../machinery/loader-store";
-    import {getRepresentative, resolveHistory} from "../../machinery/nano-rpc-fetch-wrapper";
+    import {resolveHistory} from "../../machinery/nano-rpc-fetch-wrapper";
     import {setWalletState} from "../../machinery/WalletState";
     import SendSelector from "./SendSelector.svelte";
 
@@ -53,7 +53,6 @@
         await load({
             languageId: 'loading-settings',
             load: async () => {
-                selectedAccount.representative = await getRepresentative(selectedAccount.address)
                 pushAccountAction('settings')
             },
             onError: () => {

--- a/src/view/wallet/Send.svelte
+++ b/src/view/wallet/Send.svelte
@@ -57,10 +57,10 @@
                         })
                         walletStore.set({
                             wallet: wallet,
-                            selectedAccount: updatedAccount.address
+                            account: updatedAccount,
                         })
                         pushToast({languageId: 'sent-funds-success', type: 'success'})
-                        pushAccountAction(undefined)
+                        pushAccountAction('menu')
                     } else {
                         pushToast({languageId: 'unable-to-send', type: 'warn'})
                     }

--- a/src/view/wallet/Settings.svelte
+++ b/src/view/wallet/Settings.svelte
@@ -3,24 +3,36 @@
     import Seperator from "../../components/Seperator.svelte";
     import {setWallet} from "../../machinery/secure-storage";
     import {setWalletState} from "../../machinery/WalletState";
-    import {back, navigationReload} from "../../machinery/eventListener";
+    import {back, navigationReload, pushToast} from "../../machinery/eventListener";
     import {afterUpdate} from "svelte";
     import TextInput from "../../components/input/TextInput.svelte";
     import Text from "../../components/Text.svelte";
-    import Button from "../../components/Button.svelte";
+    import TextArea from "../../components/input/TextArea.svelte";
+    import {tools} from "nanocurrency-web";
+    import {setRepresentative} from "../../machinery/nano-ops";
 
     export let wallet: NanoWallet;
     export let selectedAccount: NanoAccount;
 
     let aliasValue: string = selectedAccount?.alias
-    let setRepText: string = selectedAccount.representative ? 'change' : 'set'
+    let representativeValue: string = selectedAccount.representative
 
     const setAlias = (event) => {
         aliasValue = event.target.value;
     }
 
     const save = async () => {
+        if(aliasValue < 3) {
+            pushToast({languageId: 'onboard-alias-rule'})
+            return;
+        }
+        if(!tools.validateAddress(representativeValue)) {
+            pushToast({languageId: 'invalid-address'})
+            return;
+        }
         selectedAccount.alias = aliasValue
+        await setRepresentative(selectedAccount, representativeValue)
+        selectedAccount.representative = aliasValue;
         const updated: NanoWallet | undefined = await setWallet(wallet)
         if (updated) {
             setWalletState({wallet: updated, selectedAccount: selectedAccount?.address})
@@ -28,8 +40,8 @@
         } // TODO: Toast
     }
 
-    const changeRep = () => {
-        console.log('change reps')
+    const changeRep = (event) => {
+        representativeValue = event.target.value;
     }
 
     afterUpdate(() => navigationReload({
@@ -41,12 +53,9 @@
 
 </script>
 
-<Seperator languageId="account-settings" />
+<Seperator languageId="onboard-set-alias" />
+<Text languageId="onboard-set-alias-text"/>
 <TextInput languageId="account-alias" on:input={setAlias} bind:value={aliasValue}/>
-<Seperator languageId="set-representative" />
-{#if selectedAccount.representative}
-    <Text breakAll="true">{selectedAccount.representative}</Text>
-{:else}
-    <Text languageId="no-representative-set"/>
-{/if}
-<Button languageId={setRepText} on:click={changeRep} />
+<Seperator languageId="representative" />
+<Text languageId="representative-text"/>
+<TextArea languageId="set-representative" value={selectedAccount.representative} on:input={changeRep}/>

--- a/src/view/wallet/Settings.svelte
+++ b/src/view/wallet/Settings.svelte
@@ -6,6 +6,8 @@
     import {back, navigationReload} from "../../machinery/eventListener";
     import {afterUpdate} from "svelte";
     import TextInput from "../../components/input/TextInput.svelte";
+    import Text from "../../components/Text.svelte";
+    import Button from "../../components/Button.svelte";
 
     export let wallet: NanoWallet;
     export let selectedAccount: NanoAccount;
@@ -25,6 +27,10 @@
         } // TODO: Toast
     }
 
+    const changeRep = () => {
+        console.log('change reps')
+    }
+
     afterUpdate(() => navigationReload({
         middleKey: {
             languageId: 'button-save',
@@ -36,3 +42,6 @@
 
 <Seperator languageId="account-settings" />
 <TextInput languageId="account-alias" on:input={setAlias} bind:value={aliasValue}/>
+<Seperator languageId="set-representative" />
+<Text breakAll="true">{selectedAccount.representative}</Text>
+<Button languageId="change" on:click={changeRep} />

--- a/src/view/wallet/Settings.svelte
+++ b/src/view/wallet/Settings.svelte
@@ -13,6 +13,7 @@
     export let selectedAccount: NanoAccount;
 
     let aliasValue: string = selectedAccount?.alias
+    let setRepText: string = selectedAccount.representative ? 'change' : 'set'
 
     const setAlias = (event) => {
         aliasValue = event.target.value;
@@ -43,5 +44,9 @@
 <Seperator languageId="account-settings" />
 <TextInput languageId="account-alias" on:input={setAlias} bind:value={aliasValue}/>
 <Seperator languageId="set-representative" />
-<Text breakAll="true">{selectedAccount.representative}</Text>
-<Button languageId="change" on:click={changeRep} />
+{#if selectedAccount.representative}
+    <Text breakAll="true">{selectedAccount.representative}</Text>
+{:else}
+    <Text languageId="no-representative-set"/>
+{/if}
+<Button languageId={setRepText} on:click={changeRep} />

--- a/src/view/wallet/Settings.svelte
+++ b/src/view/wallet/Settings.svelte
@@ -14,34 +14,34 @@
     export let wallet: NanoWallet;
     export let selectedAccount: NanoAccount;
 
-    let aliasValue: string = selectedAccount?.alias
+    let aliasValue: string = selectedAccount.alias
     let representativeValue: string = selectedAccount.representative
 
-    const setAlias = (event) => {
-        aliasValue = event.target.value;
-    }
+    const setAlias = (event) => aliasValue = event.target.value;
+    const changeRep = (event) => representativeValue = event.target.value
 
     const save = async () => {
         if(aliasValue < 3) {
             pushToast({languageId: 'onboard-alias-rule'})
             return;
         }
-        if(!tools.validateAddress(representativeValue)) {
+        if(representativeValue !== undefined && !tools.validateAddress(representativeValue)) {
             pushToast({languageId: 'invalid-address'})
             return;
         }
         selectedAccount.alias = aliasValue
-        await setRepresentative(selectedAccount, representativeValue)
-        selectedAccount.representative = aliasValue;
+        selectedAccount.representative = representativeValue;
+        await setRepresentative(selectedAccount)
+        wallet.accounts = wallet.accounts.map(a => {
+            if (a.address === selectedAccount.address) {
+                return selectedAccount;
+            } else return a;
+        });
         const updated: NanoWallet | undefined = await setWallet(wallet)
         if (updated) {
-            setWalletState({wallet: updated, selectedAccount: selectedAccount?.address})
+            setWalletState({wallet: updated, account: selectedAccount})
             back()
         } // TODO: Toast
-    }
-
-    const changeRep = (event) => {
-        representativeValue = event.target.value;
     }
 
     afterUpdate(() => navigationReload({
@@ -55,7 +55,7 @@
 
 <Seperator languageId="onboard-set-alias" />
 <Text languageId="onboard-set-alias-text"/>
-<TextInput languageId="account-alias" on:input={setAlias} bind:value={aliasValue}/>
+<TextInput languageId="account-alias" value={selectedAccount.alias} on:input={setAlias}/>
 <Seperator languageId="representative" />
 <Text languageId="representative-text"/>
 <TextArea languageId="set-representative" value={selectedAccount.representative} on:input={changeRep}/>


### PR DESCRIPTION
Fixes #54 

Makes it possible to set representative (currently only by text input) in settings under an account. This made for a small refactor of when to pull account data, from "pull all history and resolve all pending for all accounts" to "pull and resolve history for one account on demand".

With these changes I also noticed that we're not resolving pending on open app, only on "update", added an issue for that.