### PR TITLE
Pockets transactions on load

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "image-capture": "^0.4.0",
     "jsqr": "^1.3.1",
-    "nano-rpc-fetch": "^1.1.4",
+    "nano-rpc-fetch": "^1.1.8",
     "nanocurrency-web": "^1.2.2",
     "qrcode": "^1.4.4",
     "redux": "^4.0.5",

--- a/public/locales/en-US.properties
+++ b/public/locales/en-US.properties
@@ -135,7 +135,7 @@ wallet-password = Set a PIN to secure the wallet
 
 # Import
 import-wallet-heading = Import wallet
-import-seed-title = Import wallet from seed or mnemonic
+import-seed-title = Import wallet from seed
 import-disclaimer-text = Importing a wallet means that the existing wallet will be unavailable. The only way to access that is to re-import it from the seed.
 import-disclaimer-text-2 = Make sure you have the existing seed written down, or transfer your funds out from the wallet before importing a new one!
 import-from-seed = Import from seed

--- a/src/machinery/models.ts
+++ b/src/machinery/models.ts
@@ -3,6 +3,7 @@ export type Seed = string;
 export type PrivateKey = string;
 export type PublicKey = string;
 export type Frontier = string;
+export type BlockHash = string;
 
 export interface NanoAccount {
   alias: string;

--- a/src/machinery/models.ts
+++ b/src/machinery/models.ts
@@ -40,3 +40,8 @@ export interface AccountInfo {
   balance: RAW;
   frontier: Frontier;
 }
+
+export interface PendingTransaction {
+  hash: BlockHash;
+  amount: RAW;
+}

--- a/src/machinery/models.ts
+++ b/src/machinery/models.ts
@@ -33,3 +33,9 @@ export interface NANO {
 export interface RAW {
   raw: string;
 }
+
+export interface AccountInfo {
+  representative: NanoAddress;
+  balance: RAW;
+  frontier: Frontier;
+}

--- a/src/machinery/models.ts
+++ b/src/machinery/models.ts
@@ -45,3 +45,8 @@ export interface PendingTransaction {
   hash: BlockHash;
   amount: RAW;
 }
+
+export interface ResolvedAccount {
+  account: NanoAccount;
+  resolvedCount: number;
+}

--- a/src/machinery/nano-ops.ts
+++ b/src/machinery/nano-ops.ts
@@ -8,6 +8,7 @@ import type {
   NanoWallet,
   PendingTransaction,
   RAW,
+  ResolvedAccount,
 } from './models';
 import {
   accountInfo,
@@ -32,8 +33,9 @@ const RECEIVE_WORK = 'fffffe0000000000';
 
 /** Calls itself until transactions are pocketed */
 export async function loadAndResolveAccountData(
-  account: NanoAccount
-): Promise<NanoAccount> {
+  account: NanoAccount,
+  resolvedCount: number = 0
+): Promise<ResolvedAccount> {
   try {
     const info: AccountInfo | undefined = await accountInfo(account.address);
     // Set rep from account info, with fallback to cached and default
@@ -47,12 +49,18 @@ export async function loadAndResolveAccountData(
     );
     if (block) {
       await receiveBlock(account, info?.frontier, block);
-      return loadAndResolveAccountData(account);
+      return loadAndResolveAccountData(account, resolvedCount + 1);
     }
-    return account;
+    return {
+      account,
+      resolvedCount: resolvedCount,
+    };
   } catch (e) {
     // TODO: Should we handle error?
-    return account;
+    return {
+      account,
+      resolvedCount: resolvedCount,
+    };
   }
 }
 

--- a/src/machinery/nano-ops.ts
+++ b/src/machinery/nano-ops.ts
@@ -2,6 +2,7 @@ import { SubType } from 'nano-rpc-fetch';
 import type { SignedBlock } from 'nanocurrency-web/dist/lib/block-signer';
 import type {
   AccountInfo,
+  BlockHash,
   Frontier,
   NanoAccount,
   NanoAddress,
@@ -74,7 +75,7 @@ export async function loadAndResolveAccountData(
 export async function receiveBlock(
   account: NanoAccount,
   frontier: Frontier | undefined,
-  blockHash: string,
+  blockHash: BlockHash,
   amount: RAW | undefined
 ): Promise<void> {
   const work = await generateWork(frontier || account.publicKey, RECEIVE_WORK);

--- a/src/machinery/nano-rpc-fetch-wrapper.ts
+++ b/src/machinery/nano-rpc-fetch-wrapper.ts
@@ -1,4 +1,10 @@
-import type { Frontier, NanoAddress, NanoTransaction, RAW } from './models';
+import type {
+  AccountInfo,
+  Frontier,
+  NanoAddress,
+  NanoTransaction,
+  RAW,
+} from './models';
 import {
   AccountBalanceRequestActionEnum,
   AccountBalanceResponse,
@@ -133,11 +139,7 @@ export async function loadFrontiers(
 
 export async function accountInfo(
   account: NanoAddress
-): Promise<{
-  frontier: NanoAddress;
-  representative: NanoAddress;
-  balance: RAW;
-}> {
+): Promise<AccountInfo | undefined> {
   const response: AccountInfoResponse = await nanoApi.accountInfo({
     accountInfoRequest: {
       action: AccountInfoRequestActionEnum.AccountInfo,
@@ -145,14 +147,19 @@ export async function accountInfo(
       representative: ModelBoolean.True,
     },
   });
-  if (response.representative === undefined) {
-    throw Error('a first receive');
+  if (
+    response.representative === undefined ||
+    response.balance === undefined ||
+    response.frontier === undefined
+  ) {
+    return undefined;
+  } else {
+    return {
+      representative: response.representative,
+      balance: {
+        raw: response.balance.toString(),
+      },
+      frontier: response.frontier,
+    };
   }
-  return {
-    representative: response.representative,
-    balance: {
-      raw: response.balance.toString(),
-    },
-    frontier: response.frontier,
-  };
 }

--- a/src/machinery/nano-rpc-fetch-wrapper.ts
+++ b/src/machinery/nano-rpc-fetch-wrapper.ts
@@ -3,6 +3,7 @@ import type {
   Frontier,
   NanoAddress,
   NanoTransaction,
+  PendingTransaction,
   RAW,
 } from './models';
 import {
@@ -110,7 +111,9 @@ export async function getPendingBlocksSimple(
   });
   return response.blocks;
 }
-export async function getPending(address: NanoAddress): Promise<{ any }> {
+export async function getPending(
+  address: NanoAddress
+): Promise<PendingTransaction | undefined> {
   const response: PendingResponse = await nanoApi.pending({
     pendingRequest: {
       action: PendingRequestActionEnum.Pending,
@@ -120,9 +123,18 @@ export async function getPending(address: NanoAddress): Promise<{ any }> {
       source: ModelBoolean.True,
     },
   });
-  console.log(response);
-  // @ts-ignore
-  return response.blocks;
+  const blocks: [hash: string, block: any][] = Object.entries(response.blocks);
+  if (blocks.length > 0) {
+    const [blockHash, { amount }] = blocks[0];
+    return {
+      hash: blockHash,
+      amount: {
+        raw: amount,
+      },
+    };
+  } else {
+    return undefined;
+  }
 }
 
 export async function loadFrontiers(

--- a/src/machinery/nano-rpc-fetch-wrapper.ts
+++ b/src/machinery/nano-rpc-fetch-wrapper.ts
@@ -55,7 +55,7 @@ export async function generateWork(
   return response.work;
 }
 
-export async function resolveHistory(
+export async function getHistory(
   address: NanoAddress
 ): Promise<NanoTransaction[]> {
   try {

--- a/src/machinery/nano-rpc-fetch-wrapper.ts
+++ b/src/machinery/nano-rpc-fetch-wrapper.ts
@@ -1,26 +1,17 @@
 import type {
   AccountInfo,
-  Frontier,
   NanoAddress,
   NanoTransaction,
   PendingTransaction,
-  RAW,
 } from './models';
 import {
-  AccountBalanceRequestActionEnum,
-  AccountBalanceResponse,
   AccountHistoryRequestActionEnum,
   AccountHistoryResponse,
   AccountInfoRequestActionEnum,
   AccountInfoResponse,
-  AccountsFrontiersRequestActionEnum,
-  AccountsFrontiersResponse,
-  AccountsPendingRequestActionEnum,
-  AccountsPendingResponse,
   Configuration,
   ModelBoolean,
   NodeRPCsApi,
-  PendingBlock,
   PendingRequestActionEnum,
   PendingResponse,
   ProcessRequestActionEnum,
@@ -36,17 +27,7 @@ const nanoApi = new NodeRPCsApi(
   })
 );
 
-export async function resolveBalance(address: NanoAddress): Promise<RAW> {
-  let balance: AccountBalanceResponse = await nanoApi.accountBalance({
-    accountBalanceRequest: {
-      action: AccountBalanceRequestActionEnum.AccountBalance,
-      account: address,
-    },
-  });
-  return { raw: balance.balance.toString() };
-}
-
-export async function processSimple(
+export async function process(
   block: any,
   subtype: SubType
 ): Promise<ProcessResponse> {
@@ -98,19 +79,6 @@ export async function resolveHistory(
   }
 }
 
-export async function getPendingBlocksSimple(
-  accounts: string[]
-): Promise<{ [key: string]: { [key: string]: PendingBlock } }> {
-  const response: AccountsPendingResponse = await nanoApi.accountsPending({
-    accountsPendingRequest: {
-      action: AccountsPendingRequestActionEnum.AccountsPending,
-      accounts: accounts,
-      count: '1',
-      source: true,
-    },
-  });
-  return response.blocks;
-}
 export async function getPending(
   address: NanoAddress
 ): Promise<PendingTransaction | undefined> {
@@ -135,18 +103,6 @@ export async function getPending(
   } else {
     return undefined;
   }
-}
-
-export async function loadFrontiers(
-  addresses: string[]
-): Promise<Map<string, Frontier> | { [key: string]: Frontier }> {
-  const response: AccountsFrontiersResponse = await nanoApi.accountsFrontiers({
-    accountsFrontiersRequest: {
-      action: AccountsFrontiersRequestActionEnum.AccountsFrontiers,
-      accounts: addresses,
-    },
-  });
-  return response.frontiers;
 }
 
 export async function accountInfo(

--- a/src/machinery/nano-rpc-fetch-wrapper.ts
+++ b/src/machinery/nano-rpc-fetch-wrapper.ts
@@ -5,8 +5,6 @@ import {
   AccountHistoryRequestActionEnum,
   AccountHistoryResponse,
   AccountRepresentativeRequestActionEnum,
-  AccountsBalancesRequestActionEnum,
-  AccountsBalancesResponse,
   AccountsFrontiersRequestActionEnum,
   AccountsFrontiersResponse,
   AccountsPendingRequestActionEnum,
@@ -39,18 +37,6 @@ export async function resolveBalance(address: NanoAddress): Promise<RAW> {
     },
   });
   return { raw: balance.balance.toString() };
-}
-
-export async function resolveBalances(
-  addresses: NanoAddress[]
-): Promise<{ [address: string]: AccountBalanceResponse }> {
-  let response: AccountsBalancesResponse = await nanoApi.accountsBalances({
-    accountsBalancesRequest: {
-      action: AccountsBalancesRequestActionEnum.AccountsBalances,
-      accounts: addresses.map((a) => a),
-    },
-  });
-  return response.balances;
 }
 
 export async function getRepresentative(

--- a/src/machinery/nanocurrency-web-wrapper.ts
+++ b/src/machinery/nanocurrency-web-wrapper.ts
@@ -1,5 +1,12 @@
 import { block, tools } from 'nanocurrency-web';
-import type { Frontier, NANO, NanoAddress, PrivateKey, RAW } from './models';
+import type {
+  BlockHash,
+  Frontier,
+  NANO,
+  NanoAddress,
+  PrivateKey,
+  RAW,
+} from './models';
 import type {
   SendBlock,
   SignedBlock,
@@ -42,7 +49,7 @@ export function signReceiveBlock(
   frontier: Frontier,
   walletBalance: RAW,
   representative: NanoAddress,
-  blockHash: string,
+  blockHash: BlockHash,
   amount: RAW
 ): SignedBlock {
   const data: ReceiveBlock = {

--- a/src/machinery/nanocurrency-web-wrapper.ts
+++ b/src/machinery/nanocurrency-web-wrapper.ts
@@ -7,9 +7,6 @@ import type {
   RepresentativeBlock,
 } from 'nanocurrency-web/dist/lib/block-signer';
 
-const DEFAULT_REP: NanoAddress =
-  'nano_3n7ky76t4g57o9skjawm8pprooz1bminkbeegsyt694xn6d31c6s744fjzzz';
-
 function round(number: number, places: number): number {
   return +(Math.round(Number(number + 'e+' + places)) + 'e-' + places);
 }
@@ -42,22 +39,19 @@ export function signReceiveBlock(
   address: NanoAddress,
   privateKey: PrivateKey,
   workHash: string,
-  pendingBlock: any,
   frontier: Frontier,
   walletBalance: RAW,
-  representative: NanoAddress | undefined
+  representative: NanoAddress,
+  blockHash: string,
+  amount: RAW
 ): SignedBlock {
-  const blockHash = Object.keys(pendingBlock)[0];
-
-  const amount = pendingBlock[blockHash].amount;
-
   const data: ReceiveBlock = {
     walletBalanceRaw: walletBalance.raw,
     toAddress: address,
     transactionHash: blockHash,
     frontier: frontier,
-    representativeAddress: representative || DEFAULT_REP,
-    amountRaw: amount,
+    representativeAddress: representative,
+    amountRaw: amount.raw,
     work: workHash,
   };
 

--- a/src/view/AccountList.svelte
+++ b/src/view/AccountList.svelte
@@ -19,6 +19,9 @@
             load: async () => {
                 const { account: updatedAccount, resolvedCount } = await loadAndResolveAccountData(account, 0)
                 const transactions = await getHistory(updatedAccount.address)
+                if (resolvedCount > 0) {
+                    pushToast({languageId: 'got-new-transactions', type: "success"})
+                }
                 setWalletState({
                     wallet: updateAccountInWallet(updatedAccount, wallet),
                     account: updatedAccount,

--- a/src/view/AccountList.svelte
+++ b/src/view/AccountList.svelte
@@ -10,16 +10,15 @@
     import {addNanoAccount} from "../machinery/wallet";
     import {truncateNanoAddress} from "../machinery/nanocurrency-web-wrapper";
     import {loadAndResolveAccountData, updateAccountInWallet} from "../machinery/nano-ops";
-    import {resolveHistory} from "../machinery/nano-rpc-fetch-wrapper";
+    import {getHistory} from "../machinery/nano-rpc-fetch-wrapper";
 
     export let wallet: NanoWallet
     const selectAccount = async (account: NanoAccount) => {
         await load({
             languageId: 'loading-account',
             load: async () => {
-                const updatedAccount = await loadAndResolveAccountData(account)
-                console.log(updatedAccount)
-                const transactions = await resolveHistory(updatedAccount.address)
+                const { account: updatedAccount, resolvedCount } = await loadAndResolveAccountData(account, 0)
+                const transactions = await getHistory(updatedAccount.address)
                 setWalletState({
                     wallet: updateAccountInWallet(updatedAccount, wallet),
                     account: updatedAccount,

--- a/src/view/AccountList.svelte
+++ b/src/view/AccountList.svelte
@@ -3,35 +3,22 @@
     import Content from "../components/Content.svelte";
     import type {NanoAccount, NanoWallet} from "../machinery/models";
     import WithSecondary from "../components/list/WithSecondary.svelte";
-    import {setWalletState} from "../machinery/WalletState";
+    import {setWalletState, updateWalletState} from "../machinery/WalletState";
     import {navigationReload, pushAccountAction, pushMenu, pushToast} from "../machinery/eventListener";
     import {afterUpdate} from "svelte";
     import {load} from "../machinery/loader-store";
     import {addNanoAccount} from "../machinery/wallet";
     import {truncateNanoAddress} from "../machinery/nanocurrency-web-wrapper";
-    import {loadAndResolveAccountData, updateAccountInWallet} from "../machinery/nano-ops";
-    import {getHistory} from "../machinery/nano-rpc-fetch-wrapper";
 
     export let wallet: NanoWallet
     const selectAccount = async (account: NanoAccount) => {
         await load({
             languageId: 'loading-account',
             load: async () => {
-                const { account: updatedAccount, resolvedCount } = await loadAndResolveAccountData(account, 0)
-                const transactions = await getHistory(updatedAccount.address)
-                if (resolvedCount > 0) {
-                    pushToast({languageId: 'got-new-transactions', type: "success"})
-                }
-                setWalletState({
-                    wallet: updateAccountInWallet(updatedAccount, wallet),
-                    account: updatedAccount,
-                    transactions: transactions,
-                })
+                await updateWalletState(account, wallet)
                 pushAccountAction('menu')
             }
         })
-
-
     }
 
     const addAccount = async () => {

--- a/src/view/AccountList.svelte
+++ b/src/view/AccountList.svelte
@@ -9,17 +9,20 @@
     import {load} from "../machinery/loader-store";
     import {addNanoAccount} from "../machinery/wallet";
     import {truncateNanoAddress} from "../machinery/nanocurrency-web-wrapper";
-    import {updateNanoAccount} from "../machinery/nano-ops";
+    import {loadAndResolveAccountData, updateAccountInWallet} from "../machinery/nano-ops";
+    import {resolveHistory} from "../machinery/nano-rpc-fetch-wrapper";
 
     export let wallet: NanoWallet
     const selectAccount = async (account: NanoAccount) => {
         await load({
             languageId: 'loading-account',
             load: async () => {
-                const updatedAccount = await updateNanoAccount(account)
+                const updatedAccount = await loadAndResolveAccountData(account)
+                const transactions = await resolveHistory(updatedAccount.address)
                 setWalletState({
-                    wallet: wallet,
-                    account: updatedAccount
+                    wallet: updateAccountInWallet(updatedAccount, wallet),
+                    account: updatedAccount,
+                    transactions: transactions,
                 })
                 pushAccountAction('menu')
             }

--- a/src/view/AccountList.svelte
+++ b/src/view/AccountList.svelte
@@ -18,6 +18,7 @@
             languageId: 'loading-account',
             load: async () => {
                 const updatedAccount = await loadAndResolveAccountData(account)
+                console.log(updatedAccount)
                 const transactions = await resolveHistory(updatedAccount.address)
                 setWalletState({
                     wallet: updateAccountInWallet(updatedAccount, wallet),

--- a/src/view/UnlockWallet.svelte
+++ b/src/view/UnlockWallet.svelte
@@ -11,7 +11,6 @@
     import {afterUpdate} from "svelte";
     import {setWalletState} from "../machinery/WalletState";
     import {load} from "../machinery/loader-store";
-    import {updateWalletAccounts} from "../machinery/nano-ops";
     import NumberInput from "../components/input/NumberInput.svelte";
     import {setSoftwareKeys} from "../machinery/SoftwareKeysState";
 
@@ -21,14 +20,6 @@
         inputPhrase = event.target.value;
         const valid = inputPhrase && inputPhrase.length >= 4
         setSoftwareKeys(softwareKeys(!valid))
-    }
-
-    const tryGetTransactions = async (data: NanoWallet) => {
-        try {
-            return await updateWalletAccounts(data)
-        } catch (e) {
-            return data;
-        }
     }
 
     const unlock = async () => {

--- a/src/view/wallet/Account.svelte
+++ b/src/view/wallet/Account.svelte
@@ -15,7 +15,7 @@
     import {SOFT_KEY_MENU} from "../../machinery/SoftwareKeysState";
     import {walletStore} from "../../stores/stores";
     import {load} from "../../machinery/loader-store";
-    import {resolveHistory} from "../../machinery/nano-rpc-fetch-wrapper";
+    import {getHistory} from "../../machinery/nano-rpc-fetch-wrapper";
     import {setWalletState} from "../../machinery/WalletState";
     import SendSelector from "./SendSelector.svelte";
 
@@ -38,7 +38,7 @@
         await load({
             languageId: 'loading-transactions',
             load: async () => {
-                const resolvedTransactions = await resolveHistory(selectedAccount.address)
+                const resolvedTransactions = await getHistory(selectedAccount.address)
                 setWalletState({
                     wallet: wallet,
                     account: selectedAccount,
@@ -65,9 +65,10 @@
         await load({
             languageId: 'loading-refresh',
             load: async () => {
-                const updatedAccount = await loadAndResolveAccountData(selectedAccount)
-                const resolvedTransactions = await resolveHistory(selectedAccount.address)
-                if (resolvedTransactions.length > 0) {
+                console.log(selectedAccount)
+                const { account: updatedAccount, resolvedCount } = await loadAndResolveAccountData(selectedAccount, 0)
+                const resolvedTransactions = await getHistory(selectedAccount.address)
+                if (resolvedCount > 0) {
                     pushToast({languageId: 'got-new-transactions', type: "success"})
                 }
                 walletStore.set({

--- a/src/view/wallet/Account.svelte
+++ b/src/view/wallet/Account.svelte
@@ -7,7 +7,7 @@
     import Receive from "./Receive.svelte";
     import type {AccountAction} from "../../machinery/NavigationState";
     import {navigationReload, pushAccountAction, pushToast} from "../../machinery/eventListener";
-    import {loadWalletData} from "../../machinery/nano-ops";
+    import {loadAndResolveAccountData, updateAccountInWallet} from "../../machinery/nano-ops";
     import {rawToNano} from "../../machinery/nanocurrency-web-wrapper";
     import Settings from "./Settings.svelte";
     import SendByAddress from "./Send.svelte";
@@ -65,17 +65,13 @@
         await load({
             languageId: 'loading-refresh',
             load: async () => {
-                // TODO: Refresh transactions as well?
-                const updatedAccount = await loadWalletData(selectedAccount)
+                const updatedAccount = await loadAndResolveAccountData(selectedAccount)
                 const resolvedTransactions = await resolveHistory(selectedAccount.address)
                 if (resolvedTransactions.length > 0) {
                     pushToast({languageId: 'got-new-transactions', type: "success"})
                 }
-                wallet.accounts = wallet.accounts.map(account => {
-                    return account.address === updatedAccount.address ? updatedAccount : account
-                })
                 walletStore.set({
-                    wallet: wallet,
+                    wallet: updateAccountInWallet(updatedAccount, wallet),
                     account: updatedAccount,
                     transactions: resolvedTransactions,
                 })

--- a/src/view/wallet/Account.svelte
+++ b/src/view/wallet/Account.svelte
@@ -65,7 +65,6 @@
         await load({
             languageId: 'loading-refresh',
             load: async () => {
-                console.log(selectedAccount)
                 const { account: updatedAccount, resolvedCount } = await loadAndResolveAccountData(selectedAccount, 0)
                 const resolvedTransactions = await getHistory(selectedAccount.address)
                 if (resolvedCount > 0) {

--- a/src/view/wallet/Send.svelte
+++ b/src/view/wallet/Send.svelte
@@ -50,7 +50,7 @@
             await load({
                 languageId: 'sending-funds',
                 load: async () => {
-                    const updatedAccount: NanoAccount | undefined = await sendNano(account, toAddress, nanoToRaw({amount: sendValue.toString()}), balance)
+                    const updatedAccount: NanoAccount | undefined = await sendNano(account, toAddress, nanoToRaw({amount: sendValue.toString()}))
                     if (updatedAccount) {
                         wallet.accounts = wallet.accounts.map(account => {
                             return account.address === updatedAccount.address ? updatedAccount : account

--- a/src/view/wallet/Send.svelte
+++ b/src/view/wallet/Send.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import type {NanoAddress, NanoAccount, RAW, NanoWallet} from "../../machinery/models";
     import {tools} from "nanocurrency-web";
-    import {sendNano} from "../../machinery/nano-ops";
+    import {sendNano, updateAccountInWallet} from "../../machinery/nano-ops";
     import {nanoToRaw, rawToNano} from "../../machinery/nanocurrency-web-wrapper";
     import CameraCapture from "../../components/CameraCapture.svelte";
     import {navigationReload, pushAccountAction, pushToast} from "../../machinery/eventListener";
@@ -10,6 +10,7 @@
     import {load} from "../../machinery/loader-store";
     import {afterUpdate} from "svelte";
     import TextInput from "../../components/input/TextInput.svelte";
+    import {setWalletState} from "../../machinery/WalletState";
 
     export let wallet: NanoWallet;
     export let sendType: AccountAction;
@@ -52,11 +53,8 @@
                 load: async () => {
                     const updatedAccount: NanoAccount | undefined = await sendNano(account, toAddress, nanoToRaw({amount: sendValue.toString()}))
                     if (updatedAccount) {
-                        wallet.accounts = wallet.accounts.map(account => {
-                            return account.address === updatedAccount.address ? updatedAccount : account
-                        })
-                        walletStore.set({
-                            wallet: wallet,
+                        setWalletState({
+                            wallet: updateAccountInWallet(updatedAccount, wallet),
                             account: updatedAccount,
                         })
                         pushToast({languageId: 'sent-funds-success', type: 'success'})


### PR DESCRIPTION
Fetches more info when pressing an account in the account list. Fixes #98 (but keeps both places). Also fixes #106, also fixes #74

* fetches representative prior to resolving blocks
* skips trying to resolve pending if there is none (this dropped 3 node calls)
* added helper function to update the Wallet after an Account has been updated

Not 100% satisified with the solution, we can at least save one RPC call by calling `account_info` which can give us balance + representative. That can be fixed in the next round.