### PR TITLE
Keep state after sending

### DIFF
--- a/src/view/wallet/Account.svelte
+++ b/src/view/wallet/Account.svelte
@@ -118,7 +118,7 @@
     {:else if action === 'send_qr'}
         <CameraCapture scannedAddress={sendToAccount} bind:cameraGranted/>
     {:else if action === 'send_address'}
-        <SendByAddress wallet={wallet} account={selectedAccount} balance={selectedAccount.balance} toAddress={sendToAddress} />
+        <SendByAddress walletState={walletState} />
     {:else if action === 'receive'}
         <Receive account={selectedAccount} />
     {:else if action === 'settings'}

--- a/src/view/wallet/Send.svelte
+++ b/src/view/wallet/Send.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-    import type {NanoAddress, NanoAccount, RAW, NanoWallet} from "../../machinery/models";
+    import type {NanoAccount} from "../../machinery/models";
+    import type { WalletState } from "../../machinery/WalletState";
     import {tools} from "nanocurrency-web";
     import {sendNano, updateAccountInWallet} from "../../machinery/nano-ops";
     import {nanoToRaw, rawToNano} from "../../machinery/nanocurrency-web-wrapper";
@@ -13,10 +14,11 @@
     import {getLanguage} from "../../machinery/language";
     import Text from "../../components/Text.svelte";
 
-    export let wallet: NanoWallet;
-    export let account: NanoAccount;
-    export let balance: RAW;
-    export let toAddress: NanoAddress | undefined = undefined
+    export let walletState: WalletState;
+    $: wallet = walletState.wallet;
+    $: account = walletState.account;
+    $: balance = account.balance;
+    $: toAddress = walletState.sendToAddress
 
     let sending: boolean = false;
     let sendValue: number | undefined = undefined
@@ -69,6 +71,8 @@
                     setWalletState({
                         wallet: updateAccountInWallet(updatedAccount, wallet),
                         account: updatedAccount,
+                        transactions: walletState.transactions,
+                        transaction: walletState.transaction,
                     })
                     pushToast({languageId: 'sent-funds-success', type: 'success'})
                     pushAccountAction('menu')


### PR DESCRIPTION
Pressing "back" should not result in white screen. Fixes #155. Keep transactions+transaction state, nulls out send to address for security reasons. 

Transactions are not updated, so going back would present the transaction list without the "latest" transaction. But I think that is fine.